### PR TITLE
Use explicit NumPyro priors for population hyperparameters

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -456,18 +456,54 @@ def make_hierarchical_log_likelihood(
 def make_numpyro_model(log_likelihood_fn: callable) -> callable:
     """Wrap the hierarchical log-likelihood as a NumPyro model.
 
-    All 10 population parameters are sampled with flat (Uniform) priors
-    matching the bounds in POP_PARAMS. This is equivalent to treating the
-    likelihood as the posterior — the priors are intentionally uninformative.
-
-    The Uniform priors are implemented as constraints rather than explicit
-    prior terms, using numpyro.sample with dist.Uniform. This gives NUTS
-    the correct geometry for the bounded parameter space.
+    The population hyperparameters use explicit, weakly informative priors
+    chosen for each parameter type instead of flat priors over POP_PARAMS.
+    Keep POP_PARAM_NAMES order unchanged when packing the sampled values into
+    lp_vec, because downstream likelihood, output, and plotting code assume
+    that vector order.
     """
     def model():
         params = {}
-        for name, lo, hi in POP_PARAMS:
-            params[name] = numpyro.sample(name, dist.Uniform(lo, hi))
+        params["mu_logalpha1"] = numpyro.sample(
+            "mu_logalpha1",
+            dist.Normal(0.0, 1.5),
+        )
+        params["sig_logalpha1"] = numpyro.sample(
+            "sig_logalpha1",
+            dist.Exponential(1.0),
+        )
+        params["mu_logalpha2"] = numpyro.sample(
+            "mu_logalpha2",
+            dist.Normal(0.0, 1.5),
+        )
+        params["sig_logalpha2"] = numpyro.sample(
+            "sig_logalpha2",
+            dist.Exponential(1.0),
+        )
+        params["a_f1"] = numpyro.sample(
+            "a_f1",
+            dist.Gamma(2.0, 1.0),
+        )
+        params["b_f1"] = numpyro.sample(
+            "b_f1",
+            dist.Gamma(2.0, 1.0),
+        )
+        params["a_f2"] = numpyro.sample(
+            "a_f2",
+            dist.Gamma(2.0, 1.0),
+        )
+        params["b_f2"] = numpyro.sample(
+            "b_f2",
+            dist.Gamma(2.0, 1.0),
+        )
+        params["sigma_v1"] = numpyro.sample(
+            "sigma_v1",
+            dist.HalfNormal(150.0),
+        )
+        params["sigma_v2"] = numpyro.sample(
+            "sigma_v2",
+            dist.HalfNormal(150.0),
+        )
 
         # Pack into a single vector for the JIT-compiled likelihood
         lp_vec = jnp.array([params[name] for name in POP_PARAM_NAMES])


### PR DESCRIPTION
### Motivation
- Replace the previous flat `dist.Uniform` constraints over `POP_PARAMS` with explicit, weakly informative priors so the model encodes sensible prior information and NUTS sees the correct log prior geometry. 
- Keep the existing parameter vector ordering used by downstream likelihood, output, and plotting code by continuing to pack sampled values using `POP_PARAM_NAMES`.

### Description
- Replaced the `for name, lo, hi in POP_PARAMS: params[name] = numpyro.sample(name, dist.Uniform(lo, hi))` loop in `make_numpyro_model()` with explicit `numpyro.sample` calls for each hyperparameter. 
- Assigned `mu_logalpha1` and `mu_logalpha2` centered `Normal(0.0, 1.5)` priors. 
- Assigned `sig_logalpha1` and `sig_logalpha2` positive scale priors using `Exponential(1.0)`. 
- Assigned `a_f1`, `b_f1`, `a_f2`, and `b_f2` Gamma shape priors using `Gamma(2.0, 1.0)`. 
- Assigned `sigma_v1` and `sigma_v2` positive scale priors using `HalfNormal(150.0)`. 
- Continued to pack sampled values into `lp_vec = jnp.array([params[name] for name in POP_PARAM_NAMES])` and left the likelihood factor call unchanged.

### Testing
- Ran `python -m py_compile hierarchical_backpop_jax.py` and the file compiled successfully. 
- Searched the codebase with `rg` to confirm removal of the `for name, lo, hi in POP_PARAMS` / `dist.Uniform` pattern and to verify `POP_PARAM_NAMES` is still used, and the checks passed. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0252d5b954832bb122a86fe65ee024)