### PR TITLE
Hard-error on unimplemented 'interpolator' selection mode

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -848,21 +848,42 @@ def parse_args():
 # Main
 # ---------------------------------------------------------------------------
 
+def determine_selection_mode(injections_path: str | None, lvk_found_path: str | None) -> str:
+    """Validate selection-effect inputs and return the implemented mode.
+
+    COSMIC injections alone used to select the unimplemented ``interpolator``
+    mode.  That silently skipped selection correction because no interpolator
+    ``log_alpha_fn`` exists in this JAX driver.  Hard-error instead so users do
+    not accidentally run a mislabeled, uncorrected analysis.
+    """
+    has_cosmic = bool(injections_path)
+    has_lvk = bool(lvk_found_path)
+
+    if has_lvk and not has_cosmic:
+        raise ValueError("--lvk_found_path requires --injections_path")
+    if has_cosmic and not has_lvk:
+        raise NotImplementedError(
+            "--injections_path without --lvk_found_path would select the "
+            "unimplemented interpolator selection mode. Provide "
+            "--lvk_found_path to enable the LVK/Farr selection correction, or "
+            "omit --injections_path to run with selection effects disabled."
+        )
+
+    return "lvk_farr" if (has_lvk and has_cosmic) else "none"
+
+
 def main():
     start_time = time.time()
     opts       = parse_args()
     np.random.seed(opts.seed)
 
-    # Determine selection mode
-    has_cosmic = bool(opts.injections_path)
-    has_lvk    = bool(opts.lvk_found_path)
-    if has_lvk and not has_cosmic:
-        raise ValueError("--lvk_found_path requires --injections_path")
-    selection_mode = "lvk_farr" if (has_lvk and has_cosmic) else \
-                     "interpolator" if has_cosmic else "none"
+    selection_mode = determine_selection_mode(
+        opts.injections_path,
+        opts.lvk_found_path,
+    )
 
     # Output directory
-    _tag = {"none": "no_selection", "interpolator": "interp", "lvk_farr": "lvk_farr"}
+    _tag = {"none": "no_selection", "lvk_farr": "lvk_farr"}
     out_dir = opts.output_dir or os.path.join(
         opts.results_root, "hierarchical", opts.config_name, "nuts",
         _tag[selection_mode]

--- a/tests/test_selection_mode.py
+++ b/tests/test_selection_mode.py
@@ -1,0 +1,40 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _load_determine_selection_mode():
+    """Load only the pure helper so tests do not require JAX/NumPyro deps."""
+    source = Path(__file__).resolve().parents[1] / "hierarchical_backpop_jax.py"
+    module_ast = ast.parse(source.read_text())
+    helper = next(
+        node for node in module_ast.body
+        if isinstance(node, ast.FunctionDef) and node.name == "determine_selection_mode"
+    )
+    mod = ast.Module(body=[helper], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    namespace = {}
+    exec(compile(mod, str(source), "exec"), namespace)
+    return namespace["determine_selection_mode"]
+
+
+determine_selection_mode = _load_determine_selection_mode()
+
+
+def test_selection_mode_none_without_selection_inputs():
+    assert determine_selection_mode(None, None) == "none"
+
+
+def test_selection_mode_lvk_farr_requires_both_inputs():
+    assert determine_selection_mode("cosmic.npz", "lvk.hdf5") == "lvk_farr"
+
+
+def test_lvk_found_path_requires_injections_path():
+    with pytest.raises(ValueError, match="requires --injections_path"):
+        determine_selection_mode(None, "lvk.hdf5")
+
+
+def test_cosmic_only_interpolator_mode_hard_errors():
+    with pytest.raises(NotImplementedError, match="unimplemented interpolator"):
+        determine_selection_mode("cosmic.npz", None)


### PR DESCRIPTION
### Motivation
- Prevent silently running with the unimplemented `interpolator` selection mode when `--injections_path` is provided without `--lvk_found_path`, which previously left `log_alpha_fn = None` and produced an unlabeled, uncorrected analysis.

### Description
- Added `determine_selection_mode(injections_path, lvk_found_path)` to validate selection-effect CLI inputs and return the implemented mode (`"lvk_farr"` or `"none"`).
- `main()` now uses `determine_selection_mode()` and no longer allows the unsupported `"interpolator"` path to proceed, and the output tag mapping for `interpolator` was removed.
- Added focused tests in `tests/test_selection_mode.py` that import only the new helper via AST so they run without JAX/NumPyro dependencies.

### Testing
- Ran `pytest -q tests/test_selection_mode.py`, which executed the focused unit tests and reported `4 passed`.
- Ran `python -m py_compile hierarchical_backpop_jax.py` to verify syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee07add9c832b9337fda9d9137786)