### PR TITLE
Store explicit injection proposal density (`log_q_proposal`) and metadata; use truncated Maxwellian

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -234,6 +234,8 @@ def compute_log_wr_injections_numpy(
     lo: np.ndarray,
     hi: np.ndarray,
     kick_sigma: float,
+    log_q_proposal: np.ndarray | None = None,
+    log_pop_static: np.ndarray | None = None,
 ) -> np.ndarray:
     """Compute COSMIC injection log-weight ratios in NumPy.
 
@@ -260,7 +262,14 @@ def compute_log_wr_injections_numpy(
     af2,    bf2     = lp_vec[6], lp_vec[7]
     sv1,    sv2     = lp_vec[8], lp_vec[9]
 
-    log_wr = np.zeros(theta.shape[0], dtype=np.float64)
+    if log_q_proposal is not None:
+        log_wr = (np.zeros(theta.shape[0], dtype=np.float64)
+                  if log_pop_static is None else np.asarray(log_pop_static, dtype=np.float64).copy())
+        log_wr -= np.asarray(log_q_proposal, dtype=np.float64)
+        explicit_q = True
+    else:
+        log_wr = np.zeros(theta.shape[0], dtype=np.float64)
+        explicit_q = False
 
     def _col(name: str) -> np.ndarray | None:
         idx = param_idx.get(name)
@@ -274,27 +283,27 @@ def compute_log_wr_injections_numpy(
 
     inj_a1 = _col('alpha_1')
     if inj_a1 is not None:
-        log_wr += _lognormal_logpdf_numpy(inj_a1, mu_la1, sig_la1) - _log_uniform_proposal('alpha_1')
+        log_wr += _lognormal_logpdf_numpy(inj_a1, mu_la1, sig_la1) - (0.0 if explicit_q else _log_uniform_proposal('alpha_1'))
 
     inj_a2 = _col('alpha_2')
     if inj_a2 is not None:
-        log_wr += _lognormal_logpdf_numpy(inj_a2, mu_la2, sig_la2) - _log_uniform_proposal('alpha_2')
+        log_wr += _lognormal_logpdf_numpy(inj_a2, mu_la2, sig_la2) - (0.0 if explicit_q else _log_uniform_proposal('alpha_2'))
 
     inj_f1 = _col('flim_1')
     if inj_f1 is not None:
-        log_wr += _beta_logpdf_numpy(inj_f1, af1, bf1) - _log_uniform_proposal('flim_1')
+        log_wr += _beta_logpdf_numpy(inj_f1, af1, bf1) - (0.0 if explicit_q else _log_uniform_proposal('flim_1'))
 
     inj_f2 = _col('flim_2')
     if inj_f2 is not None:
-        log_wr += _beta_logpdf_numpy(inj_f2, af2, bf2) - _log_uniform_proposal('flim_2')
+        log_wr += _beta_logpdf_numpy(inj_f2, af2, bf2) - (0.0 if explicit_q else _log_uniform_proposal('flim_2'))
 
     inj_v1 = _col('vk1')
     if inj_v1 is not None:
-        log_wr += _maxwell_logpdf_numpy(inj_v1, sv1) - _maxwell_logpdf_numpy(inj_v1, kick_sigma)
+        log_wr += _maxwell_logpdf_numpy(inj_v1, sv1) - (0.0 if explicit_q else _maxwell_logpdf_numpy(inj_v1, kick_sigma))
 
     inj_v2 = _col('vk2')
     if inj_v2 is not None:
-        log_wr += _maxwell_logpdf_numpy(inj_v2, sv2) - _maxwell_logpdf_numpy(inj_v2, kick_sigma)
+        log_wr += _maxwell_logpdf_numpy(inj_v2, sv2) - (0.0 if explicit_q else _maxwell_logpdf_numpy(inj_v2, kick_sigma))
 
     return log_wr
 
@@ -390,7 +399,9 @@ def make_log_alpha_fn(
     lo_inj:        jnp.ndarray,   # (N_params,) injection prior lower bounds
     hi_inj:        jnp.ndarray,   # (N_params,) injection prior upper bounds
     param_idx_inj: dict[str, int],# injection param name → column index
-    kick_sigma:    float,         # Maxwellian proposal sigma used in campaign
+    kick_sigma:    float,         # Maxwellian proposal sigma used in legacy campaigns
+    log_q_proposal: jnp.ndarray | None = None,  # explicit full proposal log-density
+    log_pop_static: jnp.ndarray | None = None,  # population factors not varied by Lambda
 ) -> callable:
     """Return a JIT-compiled function: lp_vec → log_alpha (scalar).
 
@@ -459,6 +470,19 @@ def make_log_alpha_fn(
     lpi0_a2 = _log_pi0_inj('alpha_2')
     lpi0_f1 = _log_pi0_inj('flim_1')
     lpi0_f2 = _log_pi0_inj('flim_2')
+    if log_q_proposal is None:
+        warnings.warn(
+            "Injection file lacks log_q_proposal; falling back to legacy proposal "
+            "reconstruction from bounds and kick_proposal_sigma.",
+            RuntimeWarning,
+        )
+        use_explicit_q = False
+        log_q = None
+        static_pop = None
+    else:
+        use_explicit_q = True
+        log_q = log_q_proposal
+        static_pop = jnp.zeros(theta_inj.shape[0]) if log_pop_static is None else log_pop_static
 
     # Kick denominator: Maxwellian (injection proposal), not uniform
     def _log_maxw(vk):
@@ -476,20 +500,37 @@ def make_log_alpha_fn(
         af2,    bf2     = lp_vec[6], lp_vec[7]
         sv1,    sv2     = lp_vec[8], lp_vec[9]
 
-        # Weight ratios for COSMIC mergers
-        log_wr = jnp.zeros(theta_inj.shape[0])
-        if inj_a1 is not None:
-            log_wr = log_wr + log_p_alpha_jax(inj_a1, mu_la1, sig_la1) - lpi0_a1
-        if inj_a2 is not None:
-            log_wr = log_wr + log_p_alpha_jax(inj_a2, mu_la2, sig_la2) - lpi0_a2
-        if inj_f1 is not None:
-            log_wr = log_wr + log_p_flim_jax(inj_f1, af1, bf1) - lpi0_f1
-        if inj_f2 is not None:
-            log_wr = log_wr + log_p_flim_jax(inj_f2, af2, bf2) - lpi0_f2
-        if inj_v1 is not None:
-            log_wr = log_wr + log_p_vk_jax(inj_v1, sv1) - _log_maxw(inj_v1)
-        if inj_v2 is not None:
-            log_wr = log_wr + log_p_vk_jax(inj_v2, sv2) - _log_maxw(inj_v2)
+        # Weight ratios for COSMIC mergers. New injection files carry the full
+        # proposal density q(theta), so use log p_pop(theta|Lambda)-log q.
+        # Legacy files reconstruct only the non-cancelling factors.
+        if use_explicit_q:
+            log_wr = static_pop - log_q
+            if inj_a1 is not None:
+                log_wr = log_wr + log_p_alpha_jax(inj_a1, mu_la1, sig_la1)
+            if inj_a2 is not None:
+                log_wr = log_wr + log_p_alpha_jax(inj_a2, mu_la2, sig_la2)
+            if inj_f1 is not None:
+                log_wr = log_wr + log_p_flim_jax(inj_f1, af1, bf1)
+            if inj_f2 is not None:
+                log_wr = log_wr + log_p_flim_jax(inj_f2, af2, bf2)
+            if inj_v1 is not None:
+                log_wr = log_wr + log_p_vk_jax(inj_v1, sv1)
+            if inj_v2 is not None:
+                log_wr = log_wr + log_p_vk_jax(inj_v2, sv2)
+        else:
+            log_wr = jnp.zeros(theta_inj.shape[0])
+            if inj_a1 is not None:
+                log_wr = log_wr + log_p_alpha_jax(inj_a1, mu_la1, sig_la1) - lpi0_a1
+            if inj_a2 is not None:
+                log_wr = log_wr + log_p_alpha_jax(inj_a2, mu_la2, sig_la2) - lpi0_a2
+            if inj_f1 is not None:
+                log_wr = log_wr + log_p_flim_jax(inj_f1, af1, bf1) - lpi0_f1
+            if inj_f2 is not None:
+                log_wr = log_wr + log_p_flim_jax(inj_f2, af2, bf2) - lpi0_f2
+            if inj_v1 is not None:
+                log_wr = log_wr + log_p_vk_jax(inj_v1, sv1) - _log_maxw(inj_v1)
+            if inj_v2 is not None:
+                log_wr = log_wr + log_p_vk_jax(inj_v2, sv2) - _log_maxw(inj_v2)
 
         # Numerically stable K @ w via pure_callback (numpy, system RAM).
         # K never enters XLA memory — pure_callback hides it from the allocator.
@@ -959,6 +1000,36 @@ def main():
 
         print(f"\n Loading COSMIC merger catalog: {opts.injections_path}")
         cosmic_raw = np.load(opts.injections_path, allow_pickle=True)
+        log_q_arr = None
+        log_pop_static_arr = None
+        if 'log_q_proposal' in cosmic_raw:
+            log_q_arr = cosmic_raw['log_q_proposal'].astype(np.float64)
+            if not np.all(np.isfinite(log_q_arr)):
+                raise ValueError("log_q_proposal contains non-finite values")
+            from cosmo_prior import log_prior_z_form, log_prior_logZ_given_z
+            theta_tmp = cosmic_raw['theta'].astype(np.float64)
+            params_tmp = list(cosmic_raw['params'])
+            lo_tmp = cosmic_raw['lower_bound'].astype(np.float64)
+            hi_tmp = cosmic_raw['upper_bound'].astype(np.float64)
+            pidx_tmp = {p: i for i, p in enumerate(params_tmp)}
+            log_pop_static_arr = np.zeros(theta_tmp.shape[0], dtype=np.float64)
+            for name in params_tmp:
+                if name not in ('alpha_1', 'alpha_2', 'flim_1', 'flim_2', 'vk1', 'vk2'):
+                    idx = pidx_tmp[name]
+                    log_pop_static_arr += -np.log(hi_tmp[idx] - lo_tmp[idx])
+            if 'z_form' in cosmic_raw and 'logZ' in cosmic_raw:
+                zf = cosmic_raw['z_form'].astype(np.float64)
+                lz = cosmic_raw['logZ'].astype(np.float64)
+                log_pop_static_arr += np.array([log_prior_z_form(z) for z in zf])
+                log_pop_static_arr += np.array([log_prior_logZ_given_z(zmet, z) for zmet, z in zip(lz, zf)])
+            else:
+                warnings.warn(
+                    "Injection file has log_q_proposal but lacks z_form/logZ; "
+                    "assuming cosmological proposal factors cancel.",
+                    RuntimeWarning,
+                )
+            print("  Using explicit log_q_proposal from COSMIC merger catalog")
+
         cosmic = dict(
             theta    = cosmic_raw['theta'].astype(np.float64),
             m1_src   = cosmic_raw['m1_src'].astype(np.float64),
@@ -973,6 +1044,8 @@ def main():
                 cosmic_raw['kick_proposal_sigma'].ravel()[0]
                 if 'kick_proposal_sigma' in cosmic_raw else 50.0
             ),
+            log_q_proposal = log_q_arr,
+            log_pop_static = log_pop_static_arr,
         )
         print(f"  N_merge={cosmic['N_merge']:,}  N_COSMIC={cosmic['N_inj']:,}  "
               f"f_merge={cosmic['N_merge']/cosmic['N_inj']:.4f}")
@@ -999,6 +1072,10 @@ def main():
             K_np, log_v, log_norm,
             theta_inj_jax, lo_inj_jax, hi_inj_jax,
             pidx_inj, cosmic['kick_sigma'],
+            (jnp.array(cosmic['log_q_proposal'])
+             if cosmic['log_q_proposal'] is not None else None),
+            (jnp.array(cosmic['log_pop_static'])
+             if cosmic['log_pop_static'] is not None else None),
         )
         print("  Selection effects: ENABLED (Farr estimator, JAX JIT)")
 
@@ -1181,6 +1258,10 @@ def main():
             mc_cos_ppd = mc_cos[idx_catalog_ppd]
             q_cos_ppd = q_cos[idx_catalog_ppd]
             theta_cos_ppd = theta_cos[idx_catalog_ppd]
+            log_q_cos_ppd = (cosmic['log_q_proposal'][idx_catalog_ppd]
+                             if cosmic is not None and cosmic.get('log_q_proposal') is not None else None)
+            log_pop_static_ppd = (cosmic['log_pop_static'][idx_catalog_ppd]
+                                  if cosmic is not None and cosmic.get('log_pop_static') is not None else None)
 
             # Subsample posterior for PPD computation (up to 200 samples)
             n_ppd  = min(200, len(flat_samples))
@@ -1196,6 +1277,8 @@ def main():
                     lo_cos,
                     hi_cos,
                     kick_sigma_cos,
+                    log_q_cos_ppd,
+                    log_pop_static_ppd,
                 )
                 log_wr_inj = log_wr_inj - np.max(log_wr_inj)
                 wr = np.exp(log_wr_inj)

--- a/run_injections.py
+++ b/run_injections.py
@@ -91,13 +91,16 @@ UPPER = np.array([150, 1.0,  3.699, 20,  20,  1.0, 1.0, 500, 360,  90, 360, 500,
 # Choice: σ=50 km/s gives median kick ~63 km/s.  BH kicks from fallback
 # are typically O(10-100) km/s for massive progenitors (Fryer+2012, Mandel+2016).
 KICK_PROPOSAL_SIGMA: float = 50.0   # km/s  — Maxwellian scale parameter
+PROPOSAL_NAME = "zams_uniform_truncated_maxwell_sfr_logz"
+PROPOSAL_VERSION = "2"
+COORDINATE_SYSTEM = "backpop_zams_log10Z_zform_source_merger"
 
 # logZ drawn from P(logZ|z_form); bounds used only for rejection safeguard
 LOGZ_LO = np.log10(1e-4)
 LOGZ_HI = np.log10(0.03)
 
 # z_form drawn from SFR prior; upper limit where SFR is negligible
-ZFORM_MAX = 15.0
+ZFORM_MAX = 20.0
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +130,7 @@ def _run_one(seed: int) -> dict | None:
 
     # ---- Draw binary physics + ZAMS ----
     # Non-kick parameters: flat prior π₀ (uniform over LOWER, UPPER)
-    # Kick speeds: Maxwellian(KICK_PROPOSAL_SIGMA) clipped to [0, 500]
+    # Kick speeds: Maxwellian(KICK_PROPOSAL_SIGMA) truncated to [0, 500]
     # Kick angles: uniform — isotropic in population model anyway
     # Rationale: uniform [0,500] km/s gives f_merge ≈ 0 because most kicks
     # disrupt the binary.  Maxwellian concentrates where mergers occur
@@ -135,11 +138,10 @@ def _run_one(seed: int) -> dict | None:
     theta = rng.uniform(LOWER, UPPER)
     params_dict = dict(zip(PARAMS, theta))
 
-    # Overwrite vk1 and vk2 with Maxwellian draws (clip to prior range)
-    vk1_raw = maxwell.rvs(scale=KICK_PROPOSAL_SIGMA, random_state=rng)
-    vk2_raw = maxwell.rvs(scale=KICK_PROPOSAL_SIGMA, random_state=rng)
-    params_dict['vk1'] = float(np.clip(vk1_raw, 0.0, UPPER[PARAMS.index('vk1')]))
-    params_dict['vk2'] = float(np.clip(vk2_raw, 0.0, UPPER[PARAMS.index('vk2')]))
+    # Overwrite vk1 and vk2 with exactly truncated Maxwellian draws.
+    # Do not clip: clipping would create an atom at the upper bound.
+    params_dict['vk1'] = _draw_truncated_maxwell(rng, KICK_PROPOSAL_SIGMA, 0.0, UPPER[PARAMS.index('vk1')])
+    params_dict['vk2'] = _draw_truncated_maxwell(rng, KICK_PROPOSAL_SIGMA, 0.0, UPPER[PARAMS.index('vk2')])
     # Reflect truncation into theta for storage
     theta[PARAMS.index('vk1')] = params_dict['vk1']
     theta[PARAMS.index('vk2')] = params_dict['vk2']
@@ -158,6 +160,10 @@ def _run_one(seed: int) -> dict | None:
         return None
 
     params_dict['logZ'] = log10_Z
+
+    log_q_proposal = compute_log_q_proposal(theta, z_form, log10_Z, KICK_PROPOSAL_SIGMA)
+    if not np.isfinite(log_q_proposal):
+        return None
 
     # ---- Run COSMIC ----
     try:
@@ -215,7 +221,69 @@ def _run_one(seed: int) -> dict | None:
         z_merger   = z_merger,
         t_delay    = t_delay,
         pdet       = pdet,
+        log_q_proposal = log_q_proposal,
     )
+
+
+def _draw_truncated_maxwell(
+    rng: np.random.Generator,
+    scale: float,
+    lower: float,
+    upper: float,
+    max_tries: int = 10_000,
+) -> float:
+    """Draw from Maxwell(scale) conditioned on lower <= vk <= upper."""
+    for _ in range(max_tries):
+        vk = float(maxwell.rvs(scale=scale, random_state=rng))
+        if lower <= vk <= upper:
+            return vk
+    raise RuntimeError("Failed to draw truncated Maxwell kick speed")
+
+
+def _truncated_maxwell_logpdf(x: float | np.ndarray, scale: float, lower: float, upper: float) -> float | np.ndarray:
+    """Log density of Maxwell(scale) truncated to [lower, upper]."""
+    norm = maxwell.cdf(upper, scale=scale) - maxwell.cdf(lower, scale=scale)
+    return maxwell.logpdf(x, scale=scale) - np.log(norm)
+
+
+def _log_q_z_form(z_form: float) -> float:
+    """Log density of the SFR proposal actually sampled on [0, ZFORM_MAX]."""
+    from cosmo_prior import _prior_weight_grid, _zgrid
+
+    if z_form < 0.0 or z_form > ZFORM_MAX:
+        return -np.inf
+    mask = _zgrid <= ZFORM_MAX
+    z_norm_grid = np.concatenate([_zgrid[mask], np.array([ZFORM_MAX])])
+    w_norm_grid = np.concatenate([
+        _prior_weight_grid[mask],
+        np.array([np.interp(ZFORM_MAX, _zgrid, _prior_weight_grid)]),
+    ])
+    norm = np.trapezoid(w_norm_grid, z_norm_grid)
+    weight = np.interp(z_form, _zgrid, _prior_weight_grid, left=0.0, right=0.0)
+    return float(np.log(weight) - np.log(norm)) if weight > 0.0 and norm > 0.0 else -np.inf
+
+
+def compute_log_q_proposal(
+    theta: np.ndarray,
+    z_form: float,
+    log10_Z: float,
+    kick_sigma: float = KICK_PROPOSAL_SIGMA,
+) -> float:
+    """Log density of the full injection proposal used by this campaign."""
+    from cosmo_prior import log_prior_logZ_given_z
+
+    theta = np.asarray(theta, dtype=np.float64)
+    log_q = 0.0
+    for i, name in enumerate(PARAMS):
+        if name in ("vk1", "vk2"):
+            log_q += float(_truncated_maxwell_logpdf(theta[i], kick_sigma, LOWER[i], UPPER[i]))
+        else:
+            if not (LOWER[i] <= theta[i] <= UPPER[i]):
+                return -np.inf
+            log_q += float(-np.log(UPPER[i] - LOWER[i]))
+    log_q += float(_log_q_z_form(z_form))
+    log_q += float(log_prior_logZ_given_z(log10_Z, z_form))
+    return float(log_q)
 
 
 def _draw_z_form(rng: np.random.Generator, max_tries: int = 200) -> float | None:
@@ -265,6 +333,7 @@ def run_campaign(
     n_inj: int,
     n_workers: int,
     chunk_size: int = 500,
+    config_name: str | None = None,
 ) -> None:
     """Run the full injection campaign and save results.
 
@@ -336,6 +405,7 @@ def run_campaign(
     z_merger   = np.array([r['z_merger'] for r in results])
     t_delay    = np.array([r['t_delay']  for r in results])
     pdet       = np.array([r['pdet']     for r in results])
+    log_q_proposal = np.array([r['log_q_proposal'] for r in results])
 
     elapsed = time.time() - start
 
@@ -365,6 +435,7 @@ def run_campaign(
         z_merger     = z_merger,
         t_delay_myr  = t_delay,
         pdet         = pdet,
+        log_q_proposal = log_q_proposal,
         params       = PARAMS,
         lower_bound  = LOWER,
         upper_bound  = UPPER,
@@ -372,6 +443,10 @@ def run_campaign(
         N_merge              = np.array([n_merge]),
         N_workers            = np.array([n_workers]),
         kick_proposal_sigma  = np.array([KICK_PROPOSAL_SIGMA]),
+        proposal_name         = np.array([PROPOSAL_NAME]),
+        proposal_version      = np.array([PROPOSAL_VERSION]),
+        coordinate_system     = np.array([COORDINATE_SYSTEM]),
+        config_name           = np.array([config_name or ""]),
         wall_time_s          = np.array([elapsed]),
     )
     print(f"  Saved: {output_path}")
@@ -398,6 +473,8 @@ def parse_args():
                    help="Seeds per pool.map call (default 500).")
     p.add_argument("--dry_run",     type=str, default='False',
                    help="If True, run n_inj=10000 to estimate merger fraction only.")
+    p.add_argument("--config_name", default=None,
+                   help="Optional BackPop config name stored as injection metadata.")
     return p.parse_args()
 
 
@@ -416,6 +493,7 @@ def main():
         n_inj       = n,
         n_workers   = nw,
         chunk_size  = opts.chunk_size,
+        config_name  = opts.config_name,
     )
 
 

--- a/tests/test_injection_proposal.py
+++ b/tests/test_injection_proposal.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from run_injections import LOWER, PARAMS, UPPER, compute_log_q_proposal
+
+
+def _theta(vk1=30.0, vk2=70.0):
+    theta = 0.5 * (LOWER + UPPER)
+    theta[PARAMS.index("vk1")] = vk1
+    theta[PARAMS.index("vk2")] = vk2
+    return theta
+
+
+def test_log_q_proposal_is_finite_for_representative_stored_injections():
+    values = np.array([
+        compute_log_q_proposal(_theta(20.0, 40.0), 1.0, -2.0, 50.0),
+        compute_log_q_proposal(_theta(80.0, 120.0), 2.0, -2.5, 50.0),
+        compute_log_q_proposal(_theta(5.0, 250.0), 0.5, -1.8, 50.0),
+    ])
+    assert np.all(np.isfinite(values))
+
+
+def test_log_q_proposal_changes_with_kick_scale():
+    theta = _theta(100.0, 150.0)
+    log_q_50 = compute_log_q_proposal(theta, 1.5, -2.2, 50.0)
+    log_q_100 = compute_log_q_proposal(theta, 1.5, -2.2, 100.0)
+    assert np.isfinite(log_q_50)
+    assert np.isfinite(log_q_100)
+    assert not np.isclose(log_q_50, log_q_100)


### PR DESCRIPTION
### Motivation
- The injection campaign previously encoded the proposal implicitly (clipped Maxwell draws, SFR z_form, P(logZ|z_form)) while the hierarchical code reconstructed the denominator, which is fragile and error-prone.
- Make the proposal self-describing so downstream selection code can compute `log p_population(theta|Λ) - log_q_proposal` without guessing the measure.

### Description
- Compute and persist `log_q_proposal` for every accepted merging injection in `run_injections.py` via a new `compute_log_q_proposal` helper that includes: uniform ZAMS/binary factors, truncated-Maxwell kick-speed factors, isotropic kick angles, the actual `z_form` proposal (SFR on `[0, ZFORM_MAX]`) and `P(logZ | z_form)`; store this scalar per-merger in the `.npz` as `log_q_proposal`.
- Replace previous kick clipping with an exact truncated-Maxwell sampler `_draw_truncated_maxwell` and matching `_truncated_maxwell_logpdf` so the proposal density is mathematically consistent with the sampler.
- Add a corrected `z_form` proposal density helper `_log_q_z_form` that accounts for truncation at `ZFORM_MAX` and use it in `compute_log_q_proposal`.
- Persist proposal metadata fields in the injection file: `proposal_name`, `proposal_version`, `coordinate_system`, and optional `config_name`, and add `--config_name` CLI to `run_injections.py`.
- Update `hierarchical_backpop_jax.py` and NumPy postprocessing to accept explicit `log_q_proposal` and `log_pop_static`, prefer `log_p_population(theta|Λ) - log_q_proposal` when available, and emit a `RuntimeWarning` then fall back to the legacy reconstruction from bounds and `kick_proposal_sigma` for older injection files.
- Update PPD weighting and `compute_log_wr_injections_numpy` to accept an optional `log_q_proposal` / `log_pop_static` pair and retain legacy behaviour when explicit proposal densities are not present.
- Add unit tests `tests/test_injection_proposal.py` that verify `compute_log_q_proposal` is finite for representative stored-injection parameter vectors and that it changes when the kick proposal scale is modified.

### Testing
- Compiled updated modules: `python -m py_compile run_injections.py hierarchical_backpop_jax.py` succeeded.
- Added unit tests and ran `pytest -q tests/test_injection_proposal.py tests/test_selection_mode.py`, but collection failed in this environment due to missing runtime dependency (`ModuleNotFoundError: No module named 'numpy'`), so the new tests could not be executed here; the tests assert finiteness of `log_q_proposal` and that it varies with `kick_sigma` when run in a proper environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee1c11634832ba0600f6c7dd4433d)