### PR TITLE
Align injection bounds with BackPop configs

### DIFF
--- a/run_hierarchical_2d.sh
+++ b/run_hierarchical_2d.sh
@@ -9,7 +9,7 @@
 # Prerequisites:
 #   1. SLURM catalog runs finished:  results/*/lucky_strikes/log_z.npy exist
 #   2. COSMIC merger catalog built:  injections/gwtc3_cosmic_mergers.npz exists
-#                                    (run_injections.py without --pdet_path)
+#                                    (run_injections.py --config_name lucky_strikes without --pdet_path)
 #   3. LVK found injection file:     $LVK_FOUND_PATH exists
 #
 # Selection effects: Farr (2019) estimator using raw LVK found injections.
@@ -51,6 +51,8 @@ RESULTS_ROOT="${RESULTS_ROOT:-./results}"
 CONFIG_NAME="lucky_strikes"
 
 INJECTIONS_PATH="${INJECTIONS_PATH:-./injections/gwtc3_cosmic_mergers.npz}"
+# Build with: python run_injections.py --config_name lucky_strikes --output_path "$INJECTIONS_PATH" ...
+INJECTION_CONFIG_NAME="${INJECTION_CONFIG_NAME:-lucky_strikes}"
 LVK_FOUND_PATH="${LVK_FOUND_PATH:-./injections/endo3_bbhpop-LIGO-T2100113-v12.hdf5}"
 
 # NUTS sampler settings

--- a/run_hierarchical_3d.sh
+++ b/run_hierarchical_3d.sh
@@ -43,6 +43,8 @@ RESULTS_ROOT="${RESULTS_ROOT:-./results}"
 CONFIG_NAME="lucky_strikes_zform"
 
 INJECTIONS_PATH="${INJECTIONS_PATH:-./injections/gwtc3_cosmic_mergers.npz}"
+# Build with: python run_injections.py --config_name lucky_strikes --output_path "$INJECTIONS_PATH" ...
+INJECTION_CONFIG_NAME="${INJECTION_CONFIG_NAME:-lucky_strikes}"
 LVK_FOUND_PATH="${LVK_FOUND_PATH:-./injections/endo3_bbhpop-LIGO-T2100113-v12.hdf5}"
 
 NUM_WARMUP="${NUM_WARMUP:-500}"
@@ -79,7 +81,7 @@ z_max = float(data['z_merger'].max())
 if z_max > 10:
     print(f'ERROR: z_merger max = {z_max:.1f} in injection NPZ.')
     print('The pre-fix cosmo_prior.py was used — z_merger values are wrong.')
-    print('Delete the NPZ and re-run run_injections.py with the fixed cosmo_prior.py.')
+    print('Delete the NPZ and re-run run_injections.py --config_name lucky_strikes with the fixed cosmo_prior.py.')
     sys.exit(1)
 print(f'Injection NPZ valid: z_merger max = {z_max:.3f}')
 " || exit 1

--- a/run_injections.py
+++ b/run_injections.py
@@ -69,19 +69,34 @@ from multiprocessing import Pool, cpu_count
 from scipy.stats import maxwell
 
 # ---------------------------------------------------------------------------
-# Parameter space (same as backpop.get_backpop_config 'lucky_strikes')
-# z_form and logZ are drawn separately from the SFR prior — not from π₀
+# Default parameter space is loaded from backpop.get_backpop_config().
+# These module globals are initialised to the default config for import-time
+# helpers/tests, and overwritten in worker processes by _worker_init().
 # ---------------------------------------------------------------------------
 
-PARAMS = [
-    'm1', 'q', 'logtb',
-    'alpha_1', 'alpha_2', 'flim_1', 'flim_2',
-    'vk1', 'theta1', 'phi1', 'omega1',
-    'vk2', 'theta2', 'phi2', 'omega2',
-]
+DEFAULT_CONFIG_NAME = "lucky_strikes"
 
-LOWER = np.array([50,  0.01, 0.0,   0.1, 0.1, 0.0, 0.0,   0,   0, -90,   0,   0,   0, -90,   0])
-UPPER = np.array([150, 1.0,  3.699, 20,  20,  1.0, 1.0, 500, 360,  90, 360, 500, 360,  90, 360])
+
+def _load_config(config_name: str):
+    from backpop import get_backpop_config
+
+    if config_name.endswith("_zform"):
+        raise NotImplementedError(
+            f"Injection campaigns for config_name={config_name!r} are not implemented. "
+            "Those configs sample z_form in the event likelihood; the injection "
+            "proposal must be updated to record the same physical z_form proposal "
+            "before they can be used consistently."
+        )
+    lower_bound, upper_bound, params_in, fixed_params = get_backpop_config(config_name)
+    return (
+        np.asarray(lower_bound, dtype=np.float64),
+        np.asarray(upper_bound, dtype=np.float64),
+        list(params_in),
+        dict(fixed_params),
+    )
+
+
+LOWER, UPPER, PARAMS, FIXED_PARAMS = _load_config(DEFAULT_CONFIG_NAME)
 
 # Kick velocity injection proposal: Maxwellian(KICK_PROPOSAL_SIGMA km/s)
 # The uniform prior [0, 500] has f_merge ~ 0 because large kicks disrupt all binaries.
@@ -107,12 +122,13 @@ ZFORM_MAX = 20.0
 # Worker function (runs in subprocess — must be importable at module level)
 # ---------------------------------------------------------------------------
 
-def _worker_init(pdet_path: str | None) -> None:
+def _worker_init(pdet_path: str | None, config_name: str = DEFAULT_CONFIG_NAME) -> None:
     """Load P_det interpolator once per worker process.
     If pdet_path is None, P_det evaluation is skipped and pdet=nan is stored.
     Use this mode when building the COSMIC merger catalog for LVKInjectionCampaign.
     """
-    global _PDET
+    global _PDET, LOWER, UPPER, PARAMS, FIXED_PARAMS
+    LOWER, UPPER, PARAMS, FIXED_PARAMS = _load_config(config_name)
     if pdet_path is None:
         _PDET = None
         return
@@ -140,11 +156,14 @@ def _run_one(seed: int) -> dict | None:
 
     # Overwrite vk1 and vk2 with exactly truncated Maxwellian draws.
     # Do not clip: clipping would create an atom at the upper bound.
-    params_dict['vk1'] = _draw_truncated_maxwell(rng, KICK_PROPOSAL_SIGMA, 0.0, UPPER[PARAMS.index('vk1')])
-    params_dict['vk2'] = _draw_truncated_maxwell(rng, KICK_PROPOSAL_SIGMA, 0.0, UPPER[PARAMS.index('vk2')])
-    # Reflect truncation into theta for storage
-    theta[PARAMS.index('vk1')] = params_dict['vk1']
-    theta[PARAMS.index('vk2')] = params_dict['vk2']
+    for kick_name in ('vk1', 'vk2'):
+        if kick_name in PARAMS:
+            i_kick = PARAMS.index(kick_name)
+            params_dict[kick_name] = _draw_truncated_maxwell(
+                rng, KICK_PROPOSAL_SIGMA, LOWER[i_kick], UPPER[i_kick]
+            )
+            # Reflect truncation into theta for storage.
+            theta[i_kick] = params_dict[kick_name]
 
     # ---- Draw z_form from SFR prior via inverse CDF (rejection sampling) ----
     # Import here so the worker subprocess gets its own copy
@@ -160,6 +179,11 @@ def _run_one(seed: int) -> dict | None:
         return None
 
     params_dict['logZ'] = log10_Z
+    if 'logZ' in PARAMS:
+        theta[PARAMS.index('logZ')] = log10_Z
+    if 'z_form' in PARAMS:
+        # Guard against future direct worker calls if _load_config was bypassed.
+        raise NotImplementedError("z_form injection parameters are not implemented")
 
     log_q_proposal = compute_log_q_proposal(theta, z_form, log10_Z, KICK_PROPOSAL_SIGMA)
     if not np.isfinite(log_q_proposal):
@@ -169,7 +193,7 @@ def _run_one(seed: int) -> dict | None:
     try:
         from backpop import evolv2
         final_state, bpp_raw, _ = evolv2(
-            params_dict, ['mass_1', 'mass_2'], fixed_params={}
+            params_dict, ['mass_1', 'mass_2'], fixed_params=FIXED_PARAMS
         )
     except Exception:
         return None
@@ -275,11 +299,16 @@ def compute_log_q_proposal(
     theta = np.asarray(theta, dtype=np.float64)
     log_q = 0.0
     for i, name in enumerate(PARAMS):
+        if not (LOWER[i] <= theta[i] <= UPPER[i]):
+            return -np.inf
         if name in ("vk1", "vk2"):
             log_q += float(_truncated_maxwell_logpdf(theta[i], kick_sigma, LOWER[i], UPPER[i]))
+        elif name == "logZ":
+            # logZ is proposed from P(logZ | z_form), not uniformly.
+            continue
+        elif name == "z_form":
+            raise NotImplementedError("z_form injection proposal is not implemented")
         else:
-            if not (LOWER[i] <= theta[i] <= UPPER[i]):
-                return -np.inf
             log_q += float(-np.log(UPPER[i] - LOWER[i]))
     log_q += float(_log_q_z_form(z_form))
     log_q += float(log_prior_logZ_given_z(log10_Z, z_form))
@@ -350,6 +379,10 @@ def run_campaign(
     chunk_size : int
         Seeds per Pool.map call — balances overhead vs memory.
     """
+    config_name = config_name or DEFAULT_CONFIG_NAME
+    global LOWER, UPPER, PARAMS, FIXED_PARAMS
+    LOWER, UPPER, PARAMS, FIXED_PARAMS = _load_config(config_name)
+
     os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
     start = time.time()
 
@@ -367,7 +400,7 @@ def run_campaign(
     with Pool(
         processes=n_workers,
         initializer=_worker_init,
-        initargs=(pdet_path,),
+        initargs=(pdet_path, config_name),
     ) as pool:
         for i in range(0, n_inj, chunk_size):
             batch = seeds[i : i + chunk_size]
@@ -439,6 +472,7 @@ def run_campaign(
         params       = PARAMS,
         lower_bound  = LOWER,
         upper_bound  = UPPER,
+        fixed_params = np.array(FIXED_PARAMS, dtype=object),
         N_inj                = np.array([n_inj]),
         N_merge              = np.array([n_merge]),
         N_workers            = np.array([n_workers]),
@@ -446,7 +480,7 @@ def run_campaign(
         proposal_name         = np.array([PROPOSAL_NAME]),
         proposal_version      = np.array([PROPOSAL_VERSION]),
         coordinate_system     = np.array([COORDINATE_SYSTEM]),
-        config_name           = np.array([config_name or ""]),
+        config_name           = np.array([config_name]),
         wall_time_s          = np.array([elapsed]),
     )
     print(f"  Saved: {output_path}")
@@ -473,8 +507,8 @@ def parse_args():
                    help="Seeds per pool.map call (default 500).")
     p.add_argument("--dry_run",     type=str, default='False',
                    help="If True, run n_inj=10000 to estimate merger fraction only.")
-    p.add_argument("--config_name", default=None,
-                   help="Optional BackPop config name stored as injection metadata.")
+    p.add_argument("--config_name", default=DEFAULT_CONFIG_NAME,
+                   help="BackPop config name whose params/bounds are used for injections (default: lucky_strikes).")
     return p.parse_args()
 
 

--- a/tests/test_injection_config_metadata.py
+++ b/tests/test_injection_config_metadata.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+import run_injections
+from backpop import get_backpop_config
+
+
+class _FakePool:
+    def __init__(self, *args, **kwargs):
+        init = kwargs.get("initializer")
+        initargs = kwargs.get("initargs", ())
+        if init is not None:
+            init(*initargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def map(self, func, batch):
+        lo, hi, params, _fixed = run_injections._load_config("lucky_strikes")
+        theta = 0.5 * (lo + hi)
+        return [
+            {
+                "theta": theta,
+                "logZ": theta[params.index("logZ")],
+                "z_form": 1.0,
+                "m1_src": 30.0,
+                "m2_src": 20.0,
+                "z_merger": 0.2,
+                "t_delay": 100.0,
+                "pdet": np.nan,
+                "log_q_proposal": -1.0,
+            }
+            for _ in batch
+        ]
+
+
+def test_saved_injection_bounds_match_backpop_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_injections, "Pool", _FakePool)
+    output_path = tmp_path / "injections.npz"
+
+    run_injections.run_campaign(
+        pdet_path=None,
+        output_path=str(output_path),
+        n_inj=1,
+        n_workers=1,
+        config_name="lucky_strikes",
+    )
+
+    lo, hi, params, fixed = get_backpop_config("lucky_strikes")
+    saved = np.load(output_path, allow_pickle=True)
+
+    assert saved["config_name"][0] == "lucky_strikes"
+    assert saved["params"].tolist() == params
+    np.testing.assert_allclose(saved["lower_bound"], lo)
+    np.testing.assert_allclose(saved["upper_bound"], hi)
+    assert saved["fixed_params"].item() == fixed


### PR DESCRIPTION
### Motivation
- Ensure injection campaigns use the same parameter support as single-event inference by removing hard-coded injection bounds and loading parameter names/bounds from `get_backpop_config(config_name)`. 
- Prevent inconsistent selection-correction integration when the injection proposal and event likelihood disagree (e.g. `m1` bounds in `lucky_strikes`).
- Make `_zform` variants explicit: either implement consistent `z_form` proposals later or fail fast to avoid silent mismatches.

### Description
- Add a `--config_name` CLI argument (default `lucky_strikes`) and wire it through `run_campaign()` and worker initialization to select the injection config via `get_backpop_config(config_name)`.
- Replace hard-coded `PARAMS`, `LOWER`, and `UPPER` with a `_load_config()` helper that returns `lower_bound`, `upper_bound`, `params_in`, and `fixed_params` from `backpop.get_backpop_config()` and initialise module globals to the default config for import-time helpers/tests.
- Update `_worker_init()` and `run_campaign()` to reload the chosen config in worker processes and before running the campaign, and use `FIXED_PARAMS` when calling `evolv2()`.
- Modify `_run_one()` to draw injection parameters from the selected `PARAMS/LOWER/UPPER`, to draw truncated-Maxwell kicks only if the corresponding kick parameter exists in `PARAMS`, to reflect `logZ` into the `theta` vector when present, and to raise `NotImplementedError` when the chosen config samples `z_form` (configs ending in `_zform`) until a consistent injection proposal is implemented.
- Adjust `compute_log_q_proposal()` to validate samples against the selected bounds, treat `logZ` as proposed from `P(logZ|z_form)` (skip uniform-box term), and fail for `z_form`-sampling configs until implemented.
- Save injection metadata into the output NPZ: `config_name`, `params`, `lower_bound`, `upper_bound`, and `fixed_params` (as `fixed_params` array) so downstream workflows can validate consistency.
- Update shell-script comments and examples in `run_hierarchical_2d.sh` and `run_hierarchical_3d.sh` to show building injection catalogs with `python run_injections.py --config_name lucky_strikes ...`.
- Add a sanity unit test `tests/test_injection_config_metadata.py` that mocks the pool, runs a tiny campaign, loads the saved NPZ and asserts that `params`/`lower_bound`/`upper_bound`/`fixed_params` match `get_backpop_config("lucky_strikes")`.

### Testing
- Ran `python -m py_compile run_injections.py` to verify the modified module compiles successfully (succeeded).
- Performed `git diff --check` to ensure no trailing/whitespace issues (passed).
- Added and executed `pytest` for `tests/test_injection_config_metadata.py` and `tests/test_injection_proposal.py`, but test collection failed due to the environment missing required runtime dependencies (`ModuleNotFoundError: No module named 'numpy'`); the new metadata test itself is designed to pass in a properly provisioned environment and asserts the NPZ `params/lower_bound/upper_bound/fixed_params` match `get_backpop_config("lucky_strikes")`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee335e7e0832b8f6fe1af3b1bdbf3)