### PR TITLE
Refactor likelihood support gates

### DIFF
--- a/backpop.py
+++ b/backpop.py
@@ -896,6 +896,7 @@ def load_gw_data(
     mass_frame: str = "auto",
     verbose: bool = True,
     return_metadata: bool = False,
+    hdi_prob: float = 0.999,
 ) -> tuple:
     """Load GW posterior samples and build a source-frame KDE likelihood.
 
@@ -931,17 +932,19 @@ def load_gw_data(
         Print available posterior sample keys and KDE diagnostics.
     return_metadata : bool
         If True, append a metadata dictionary describing mass-frame handling.
+    hdi_prob : float
+        Probability mass used for reported HDI support bounds.
 
     Returns
     -------
     kde : scipy.stats.gaussian_kde
         2D KDE over (mc, q) or 3D over (mc, q, z_src).
     q_bounds : tuple[float, float]
-        99.9% HDI of q — used as a soft prior gate in the likelihood.
+        HDI of q using ``hdi_prob`` — used by configured support gates.
     mc_bounds : tuple[float, float]
-        99.9% HDI of mc — for diagnostics and metadata.
+        HDI of mc using ``hdi_prob`` — for diagnostics and metadata.
     z_bounds : tuple[float, float] or None
-        99.9% HDI of z_src in 3D mode; None in 2D mode.
+        HDI of z_src using ``hdi_prob`` in 3D mode; None in 2D mode.
     raw_samples : np.ndarray
         Source-frame samples, shape (N, 2) or (N, 3).
 
@@ -1009,14 +1012,14 @@ def load_gw_data(
     else:
         weights = np.ones(len(m1_src)) / len(m1_src)
 
-    q_lo,  q_hi  = az.hdi(q_src,  hdi_prob=0.999)
-    mc_lo, mc_hi = az.hdi(mc_src, hdi_prob=0.999)
+    q_lo,  q_hi  = az.hdi(q_src,  hdi_prob=hdi_prob)
+    mc_lo, mc_hi = az.hdi(mc_src, hdi_prob=hdi_prob)
 
     if include_redshift:
         # Use the redshift values already implied by the PE D_L samples
         # (consistent with the PE cosmological model internally)
         z_src = redshift
-        z_lo, z_hi = az.hdi(z_src, hdi_prob=0.999)
+        z_lo, z_hi = az.hdi(z_src, hdi_prob=hdi_prob)
 
         raw_samples = np.column_stack([mc_src, q_src, z_src])
         kde = gaussian_kde(raw_samples.T, weights=weights)

--- a/run_backpop.py
+++ b/run_backpop.py
@@ -41,6 +41,12 @@ Output (./results/<event_name>/<config_name>/):
     log_z.npy      — log evidence (scalar); used in hierarchical step
     blobs.npy      — COSMIC bpp + kick tracks per sample
     metadata.npz   — self-describing run metadata for hierarchical step
+
+Support gates
+-------------
+By default ``--support_gate none`` leaves KDE tails to the KDE rather than
+applying asymmetric ad hoc penalties.  ``hard`` and ``soft`` are available for
+explicit HDI-based support truncation/penalization with ``--support_hdi``.
 """
 
 from __future__ import annotations
@@ -104,11 +110,60 @@ def _merger_observables(final_state) -> tuple[float, float, float]:
     return m1, m2, mc, q
 
 
-def _soft_q_gate(q: float, q_hi: float) -> float | None:
-    """Return a log-penalty if q exceeds the HDI upper limit, else None."""
-    if q > q_hi:
-        return -0.5 * ((q - q_hi) / 0.01)**2 - 100.0
-    return None
+_VALID_SUPPORT_GATES = ("none", "hard", "soft")
+
+
+def _support_gate_penalty(
+    value: float,
+    bounds: tuple[float, float] | None,
+    policy: str,
+    *,
+    soft_scale_fraction: float = 0.01,
+    soft_offset: float = 100.0,
+) -> float | None:
+    """Return a support-gate log penalty, or None when KDE should be used.
+
+    Policies are symmetric around the supplied HDI bounds:
+      - ``none``: never gate; leave all tail behavior to the KDE.
+      - ``hard``: return ``-np.inf`` outside the bounds.
+      - ``soft``: return a quadratic penalty below/above the bounds.
+    """
+    if policy not in _VALID_SUPPORT_GATES:
+        raise ValueError(
+            f"Unsupported support gate '{policy}'. "
+            f"Expected one of {_VALID_SUPPORT_GATES}."
+        )
+    if policy == "none" or bounds is None:
+        return None
+
+    lo, hi = map(float, bounds)
+    if lo <= value <= hi:
+        return None
+    if policy == "hard":
+        return -np.inf
+
+    width = max(hi - lo, np.finfo(float).eps)
+    scale = soft_scale_fraction * width
+    distance = lo - value if value < lo else value - hi
+    return -0.5 * (distance / scale)**2 - soft_offset
+
+
+def _combined_support_gate_penalty(
+    values: dict[str, float],
+    bounds_by_name: dict[str, tuple[float, float] | None],
+    policy: str,
+) -> float | None:
+    """Combine support penalties for all provided observables."""
+    penalties = [
+        _support_gate_penalty(values[name], bounds_by_name.get(name), policy)
+        for name in values
+    ]
+    penalties = [penalty for penalty in penalties if penalty is not None]
+    if not penalties:
+        return None
+    if any(np.isneginf(penalty) for penalty in penalties):
+        return -np.inf
+    return float(np.sum(penalties))
 
 
 def _extract_t_delay_myr(bpp_raw: np.ndarray) -> float | None:
@@ -132,6 +187,8 @@ def likelihood_2d(
     *,
     kde,
     q_bounds: tuple[float, float],
+    mc_bounds: tuple[float, float],
+    support_gate: str,
     fixed_params: dict,
 ) -> tuple[float, np.ndarray, np.ndarray]:
     """Log-likelihood for the 2D (mc, q) KDE mode.
@@ -153,7 +210,11 @@ def likelihood_2d(
     kde : scipy.stats.gaussian_kde
         2D KDE over (mc_src, q_src).  Bound via partial.
     q_bounds : tuple[float, float]
-        (q_lo, q_hi) 99.9% HDI soft gate.  Bound via partial.
+        (q_lo, q_hi) HDI used by the configured support gate.  Bound via partial.
+    mc_bounds : tuple[float, float]
+        (mc_lo, mc_hi) HDI used by the configured support gate.  Bound via partial.
+    support_gate : {"none", "hard", "soft"}
+        Support policy applied consistently to KDE observables.
     fixed_params : dict
         Fixed COSMIC parameters.  Bound via partial.
 
@@ -174,7 +235,9 @@ def likelihood_2d(
 
     _, _, mc, q = _merger_observables(final_state)
 
-    penalty = _soft_q_gate(q, q_bounds[1])
+    penalty = _combined_support_gate_penalty(
+        {"mc": mc, "q": q}, {"mc": mc_bounds, "q": q_bounds}, support_gate
+    )
     if penalty is not None:
         return penalty, bpp_flat, kick_flat
 
@@ -191,7 +254,9 @@ def likelihood_3d(
     *,
     kde,
     q_bounds: tuple[float, float],
+    mc_bounds: tuple[float, float],
     z_bounds: tuple[float, float],
+    support_gate: str,
     fixed_params: dict,
 ) -> tuple[float, np.ndarray, np.ndarray]:
     """Log-likelihood for the 3D (mc, q, z_merger) KDE mode.
@@ -220,9 +285,13 @@ def likelihood_3d(
     kde : scipy.stats.gaussian_kde
         3D KDE over (mc_src, q_src, z_src).  Bound via partial.
     q_bounds : tuple[float, float]
-        (q_lo, q_hi) 99.9% HDI soft gate.  Bound via partial.
+        (q_lo, q_hi) HDI used by the configured support gate.  Bound via partial.
+    mc_bounds : tuple[float, float]
+        (mc_lo, mc_hi) HDI used by the configured support gate.  Bound via partial.
     z_bounds : tuple[float, float]
-        (z_lo, z_hi) 99.9% HDI of merger redshift.  Bound via partial.
+        (z_lo, z_hi) HDI used by the configured support gate.  Bound via partial.
+    support_gate : {"none", "hard", "soft"}
+        Support policy applied consistently to KDE observables.
     fixed_params : dict
         Fixed COSMIC parameters.  Bound via partial.
 
@@ -277,20 +346,18 @@ def likelihood_3d(
     # ---- Merger observables ----
     _, _, mc, q = _merger_observables(final_state)
 
-    # ---- Soft mass-ratio gate ----
-    penalty = _soft_q_gate(q, q_bounds[1])
+    # ---- Configured support policy (mc, q, z) ----
+    penalty = _combined_support_gate_penalty(
+        {"mc": mc, "q": q, "z": z_merger_pred},
+        {"mc": mc_bounds, "q": q_bounds, "z": z_bounds},
+        support_gate,
+    )
     if penalty is not None:
         return penalty + lp_z + lp_logZ, bpp_flat, kick_flat
 
     # ---- 3D KDE likelihood ----
-    # Allow a 3x margin above z_hi before applying a soft penalty, since
-    # the KDE bandwidth handles tails within the HDI naturally.
-    z_hi = z_bounds[1]
-    if z_merger_pred > 3.0 * z_hi:
-        log_ll = -0.5 * ((z_merger_pred - z_hi) / (0.1 * max(z_hi, 1e-3)))**2 - 10.0
-    else:
-        coord  = np.array([[mc], [q], [z_merger_pred]])
-        log_ll = float(kde.logpdf(coord)[0])
+    coord  = np.array([[mc], [q], [z_merger_pred]])
+    log_ll = float(kde.logpdf(coord)[0])
 
     log_prob = log_ll + lp_z + lp_logZ
     return log_prob, bpp_flat, kick_flat
@@ -337,6 +404,13 @@ def parse_args():
                    help="Nautilus n_live.  3000 for hard events; 1000 for typical BBH.")
     p.add_argument("--neff",   type=int, default=30000,
                    help="Nautilus target effective sample size.")
+    p.add_argument("--support_gate", choices=_VALID_SUPPORT_GATES, default="none",
+                   help="Support treatment for KDE observables outside HDI bounds. "
+                        "Default 'none' is safer: it leaves tails to the KDE "
+                        "and avoids one-off asymmetric likelihood penalties.")
+    p.add_argument("--support_hdi", type=float, default=0.999,
+                   help="HDI probability used to define support bounds for "
+                        "--support_gate hard/soft (default: 0.999).")
     p.add_argument("--resume", type=str_to_bool, default=False,
                    help="Resume from existing Nautilus checkpoint.")
     p.add_argument("--max_threads", type=int, default=None,
@@ -348,6 +422,11 @@ def parse_args():
 def main():
     start = time.time()
     opts  = parse_args()
+
+    if not (0.0 < opts.support_hdi <= 1.0):
+        raise ValueError(
+            f"--support_hdi must be in the interval (0, 1]. Got {opts.support_hdi}."
+        )
 
     # ---- Validate config / mode consistency ----
     use_z = opts.use_redshift_likelihood
@@ -380,6 +459,7 @@ def main():
         include_redshift=use_z,
         mass_frame=opts.mass_frame,
         return_metadata=True,
+        hdi_prob=opts.support_hdi,
     )
 
     # ---- Build prior ----
@@ -422,7 +502,9 @@ def main():
             likelihood_3d,
             kde=kde,
             q_bounds=q_bounds,
+            mc_bounds=mc_bounds,
             z_bounds=z_bounds,
+            support_gate=opts.support_gate,
             fixed_params=fixed_params,
         )
     else:
@@ -430,6 +512,8 @@ def main():
             likelihood_2d,
             kde=kde,
             q_bounds=q_bounds,
+            mc_bounds=mc_bounds,
+            support_gate=opts.support_gate,
             fixed_params=fixed_params,
         )
 
@@ -489,6 +573,8 @@ def main():
         neff                    = opts.neff,
         n_eff_actual            = n_eff_actual,
         log_z                   = log_z,
+        support_gate            = opts.support_gate,
+        support_hdi             = opts.support_hdi,
         q_bounds                = q_bounds,
         mc_bounds               = mc_bounds,
         z_bounds                = (

--- a/tests/test_support_gate_policy.py
+++ b/tests/test_support_gate_policy.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from run_backpop import _combined_support_gate_penalty, _support_gate_penalty
+
+
+@pytest.mark.parametrize("value", [-1.0, 0.5, 2.0])
+def test_support_gate_none_delegates_all_tails_to_kde(value):
+    assert _support_gate_penalty(value, (0.0, 1.0), "none") is None
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_support_gate_hard_rejects_below_and_above_bounds(value):
+    assert _support_gate_penalty(value, (0.0, 1.0), "hard") == -np.inf
+
+
+def test_support_gate_hard_allows_within_bounds():
+    assert _support_gate_penalty(0.5, (0.0, 1.0), "hard") is None
+
+
+@pytest.mark.parametrize("value", [-0.01, 1.01])
+def test_support_gate_soft_penalizes_below_and_above_symmetrically(value):
+    penalty = _support_gate_penalty(value, (0.0, 1.0), "soft")
+    assert np.isfinite(penalty)
+    assert penalty == pytest.approx(-100.5)
+
+
+def test_support_gate_soft_allows_within_bounds():
+    assert _support_gate_penalty(0.5, (0.0, 1.0), "soft") is None
+
+
+def test_combined_support_gate_sums_multiple_out_of_bounds_penalties():
+    penalty = _combined_support_gate_penalty(
+        {"mc": -0.01, "q": 1.01},
+        {"mc": (0.0, 1.0), "q": (0.0, 1.0)},
+        "soft",
+    )
+    assert penalty == pytest.approx(-201.0)


### PR DESCRIPTION
### Motivation
- Remove ad-hoc asymmetric likelihood penalties (previous `_soft_q_gate` and the `z_merger_pred > 3*z_hi` penalty) and replace them with a single, consistent, configurable support policy. 
- Make support treatment transparent, symmetric, and configurable so KDE tails are handled consistently across observables.

### Description
- Introduce a shared support-gate helper: `_support_gate_penalty()` and `_combined_support_gate_penalty()` which implement three policies `"none"`, `"hard"`, and symmetric `"soft"` around supplied HDI bounds. 
- Add CLI options `--support_gate none|hard|soft` and `--support_hdi 0.999` and validate `--support_hdi` is in `(0,1]`, with documented default `none` to preserve KDE-tail behavior. 
- Apply the configured support policy consistently to `q` and `mc` in 2D mode and to `q`, `mc`, and `z` in 3D mode; remove the previous ad hoc high-redshift penalty. 
- Thread `support_hdi` into `load_gw_data()` so reported HDI bounds are computed with the user-specified probability instead of a hard-coded `0.999`. 
- Persist `support_gate` and `support_hdi` into the run `metadata.npz`. 
- Add unit tests `tests/test_support_gate_policy.py` covering below-bound, within-bound, above-bound, and combined-observable behavior for `none`/`hard`/`soft` policies.

### Testing
- Ran static compile check: `python -m py_compile run_backpop.py backpop.py`, which succeeded. 
- Ran unit tests: `pytest -q tests/test_support_gate_policy.py` was executed but collection failed in the container due to the environment lacking `numpy` (`ModuleNotFoundError: No module named 'numpy'`); the tests are present and exercise below/within/above-bound cases and should pass in an environment with the usual scientific stack installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eefe0c410832b8813cce27708c0c7)