### PR TITLE
Promote guarded 3D hierarchical workflow

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -1,0 +1,41 @@
+# BackPop hierarchical workflows
+
+## Recommended production workflow: 3D selection-corrected inference
+
+Use `run_hierarchical_3d.sh` for production population inference. This is the default scientific workflow because the selection function depends on both mass and redshift, and the 3D single-event likelihood/injection campaign keeps the event posterior base measure consistent with the LVK/Farr selection correction.
+
+End-to-end outline:
+
+1. Run the 3D single-event catalog with `lucky_strikes_zform` so each event writes `points.npy`, `log_w.npy`, `log_z.npy`, and mode metadata with `likelihood_mode=3D`.
+2. Build the matching COSMIC merger injection catalog with `run_injections.py --config_name lucky_strikes_zform --likelihood_mode 3D --output_path ./injections/gwtc3_cosmic_mergers.npz`.
+3. Provide the LVK found-injection file through `LVK_FOUND_PATH`.
+4. Launch `./run_hierarchical_3d.sh`.
+
+The script fails before sampling if event metadata, injection metadata, required files/fields, or selection-correction inputs are missing or inconsistent. Set `ALLOW_INCONSISTENT_SELECTION_MODEL=True` only for an intentional legacy diagnostic run.
+
+## Fast diagnostic 2D workflow
+
+Use `run_hierarchical_2d.sh` for quick comparisons to the Lucky Strikes-style 2D likelihood or for debugging sampler behavior. It is not the recommended production workflow unless you also provide a self-consistent 2D injection campaign generated with `--likelihood_mode 2D` and matching 2D event metadata.
+
+The 2D script keeps the command-line interface unchanged and performs the same preflight consistency checks as the 3D script.
+
+## No-selection smoke test
+
+For a fast smoke test of the hierarchical sampler only, call `hierarchical_backpop_jax.py` directly and omit both `--injections_path` and `--lvk_found_path`. This intentionally disables selection effects and should not be used for scientific population constraints.
+
+Example:
+
+```bash
+python hierarchical_backpop_jax.py \
+  --results_root ./results \
+  --config_name lucky_strikes_zform \
+  --output_dir ./results/hierarchical/lucky_strikes_zform/nuts/no_selection_smoke \
+  --n_samples 200 \
+  --num_warmup 50 \
+  --num_samples 50 \
+  --num_chains 1
+```
+
+## Selection-estimator comparison
+
+Use the workflow scripts for the guarded LVK/Farr estimator runs, then compare against alternative estimators or sampler implementations in separate output directories. Keep the event likelihood mode and injection campaign mode matched for every comparison. If comparing 2D and 3D, treat the 2D run as a diagnostic sensitivity check rather than a production replacement.

--- a/run_hierarchical_2d.sh
+++ b/run_hierarchical_2d.sh
@@ -3,6 +3,10 @@
 # run_hierarchical_2d.sh
 #
 # Hierarchical BackPop population inference — 2D likelihood mode.
+# DIAGNOSTIC/COMPARISON WORKFLOW, not the recommended production path.
+# Use 2D selection-corrected inference only with a self-consistent 2D
+# injection campaign; production selection-corrected inference should use
+# run_hierarchical_3d.sh because selection effects are mass-redshift dependent.
 # Uses lucky_strikes posteriors (KDE over mc, q — flat logZ prior).
 # Sampler: NumPyro NUTS (HMC), implemented in hierarchical_backpop_jax.py.
 #
@@ -39,6 +43,7 @@
 #   NUM_CHAINS=4          independent chains (need >= 2 for R-hat)
 #   N_SAMPLES=10000       per-event importance sampling draws
 #   LVK_N_FOUND_MAX=5000  LVK injections to use for K matrix (speed vs variance)
+#   ALLOW_INCONSISTENT_SELECTION_MODEL=False  set True only for intentional legacy diagnostics
 # =============================================================================
 
 set -euo pipefail
@@ -66,6 +71,7 @@ NUM_CHAINS="${NUM_CHAINS:-2}"        # must be >= 2 for R-hat diagnostics
 # Data settings
 N_SAMPLES="${N_SAMPLES:-5000}"          # per-event importance sampling draws
 LVK_N_FOUND_MAX="${LVK_N_FOUND_MAX:-30000}"  # subsample LVK found injections for speed
+ALLOW_INCONSISTENT_SELECTION_MODEL="${ALLOW_INCONSISTENT_SELECTION_MODEL:-False}"  # explicit legacy/diagnostic override
                                              # Farr variance ~ 1/N_found; 5000 >> needed
 
 OUTPUT_DIR="${RESULTS_ROOT}/hierarchical/${CONFIG_NAME}/nuts/lvk_farr"
@@ -100,6 +106,87 @@ for f in "${INJECTIONS_PATH}" "${LVK_FOUND_PATH}"; do
     fi
 done
 
+# Validate mode metadata and required fields before launching an expensive run.
+echo ""
+echo ">>> Checking event/injection metadata consistency..."
+python - "${RESULTS_ROOT}" "${CONFIG_NAME}" "${INJECTIONS_PATH}" "${LVK_FOUND_PATH}" "${ALLOW_INCONSISTENT_SELECTION_MODEL}" "2D" <<'PY'
+import glob
+import os
+import sys
+import numpy as np
+
+results_root, config_name, injections_path, lvk_found_path, allow_raw, expected_mode = sys.argv[1:7]
+allow = str(allow_raw).strip().lower() in {"1", "true", "yes", "y"}
+expected_3d = expected_mode == "3D"
+required_event_keys = {"params_in", "lower_bound", "upper_bound", "event_name", "likelihood_mode", "uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"}
+required_event_files = {"points.npy", "log_w.npy", "log_z.npy", "metadata.npz"}
+required_injection_keys = {"theta", "m1_src", "m2_src", "z_merger", "params", "lower_bound", "upper_bound", "N_inj", "N_merge", "likelihood_mode", "uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"}
+
+def fail(msg):
+    if allow:
+        print(f"OVERRIDE WARNING: {msg}")
+    else:
+        print(f"ERROR: {msg}")
+        print("Set ALLOW_INCONSISTENT_SELECTION_MODEL=True only for an intentional legacy/diagnostic override.")
+        sys.exit(1)
+
+def scalar(npz, key):
+    val = npz[key]
+    if getattr(val, "shape", ()) == ():
+        return val.item()
+    if val.size == 1:
+        item = val.ravel()[0]
+        return item.item() if hasattr(item, "item") else item
+    return val
+
+def as_bool(x):
+    if isinstance(x, (bool, np.bool_)):
+        return bool(x)
+    return str(x).strip().lower() in {"1", "true", "yes", "y"}
+
+if not injections_path or not lvk_found_path:
+    fail("Selection correction is not enabled: both INJECTIONS_PATH and LVK_FOUND_PATH are required by this workflow script.")
+for path, label in [(injections_path, "injection NPZ"), (lvk_found_path, "LVK found injection file")]:
+    if not os.path.isfile(path):
+        print(f"ERROR: Missing {label}: {path}")
+        sys.exit(1)
+
+event_dirs = sorted(os.path.dirname(p) for p in glob.glob(os.path.join(results_root, "*", config_name, "log_z.npy")))
+if len(event_dirs) < 2:
+    print(f"ERROR: Need at least 2 completed {config_name} events; found {len(event_dirs)}.")
+    sys.exit(1)
+
+for d in event_dirs:
+    missing_files = sorted(f for f in required_event_files if not os.path.isfile(os.path.join(d, f)))
+    if missing_files:
+        print(f"ERROR: Event directory {d} is missing required files: {missing_files}")
+        sys.exit(1)
+    meta = np.load(os.path.join(d, "metadata.npz"), allow_pickle=True)
+    missing_keys = sorted(required_event_keys - set(meta.files))
+    if missing_keys:
+        fail(f"Event metadata {d}/metadata.npz is missing mode/required keys: {missing_keys}")
+        continue
+    mode = str(scalar(meta, "likelihood_mode")).upper()
+    flags = {k: as_bool(scalar(meta, k)) for k in ["uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"]}
+    if mode != expected_mode or any(v != expected_3d for v in flags.values()):
+        fail(f"Event metadata in {d} does not match {expected_mode}: likelihood_mode={mode}, flags={flags}")
+
+inj = np.load(injections_path, allow_pickle=True)
+missing_inj = sorted(required_injection_keys - set(inj.files))
+if missing_inj:
+    fail(f"Injection metadata/file is missing required keys: {missing_inj}")
+else:
+    inj_mode = str(scalar(inj, "likelihood_mode")).upper()
+    inj_flags = {k: as_bool(scalar(inj, k)) for k in ["uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"]}
+    if inj_mode != expected_mode or any(v != expected_3d for v in inj_flags.values()):
+        fail(f"Injection metadata does not match {expected_mode}: likelihood_mode={inj_mode}, flags={inj_flags}")
+    if int(np.ravel(inj["N_merge"])[0]) <= 0 or len(inj["z_merger"]) == 0:
+        print("ERROR: Injection catalog has no merging/redshift samples for selection correction.")
+        sys.exit(1)
+
+print(f"Metadata preflight OK: {len(event_dirs)} {expected_mode} events, matching {expected_mode} injections, LVK/Farr selection enabled.")
+PY
+
 mkdir -p "${OUTPUT_DIR}"
 
 echo ""
@@ -121,6 +208,7 @@ python hierarchical_backpop_jax.py \
     --num_samples       "${NUM_SAMPLES}" \
     --num_chains        "${NUM_CHAINS}" \
     --lvk_n_found_max   "${LVK_N_FOUND_MAX}" \
+    --allow_inconsistent_selection_model "${ALLOW_INCONSISTENT_SELECTION_MODEL}" \
     2>&1 | tee "${OUTPUT_DIR}/run.log"
 
 # ---------------------------------------------------------------------------

--- a/run_hierarchical_3d.sh
+++ b/run_hierarchical_3d.sh
@@ -3,6 +3,7 @@
 # run_hierarchical_3d.sh
 #
 # Hierarchical BackPop population inference — 3D likelihood mode.
+# RECOMMENDED PRODUCTION SCRIPT for selection-corrected hierarchical inference.
 # Uses lucky_strikes_zform posteriors (KDE over mc, q, z_merger +
 # Andrews+2021 cosmological priors on z_form and logZ).
 # Sampler: NumPyro NUTS (HMC), implemented in hierarchical_backpop_jax.py.
@@ -13,7 +14,7 @@
 #   3. COSMIC merger catalog re-run with fixed cosmo_prior.py:
 #      injections/gwtc3_cosmic_mergers.npz  (old pre-fix NPZ is invalid)
 #   4. LVK found injection file available.
-#   5. run_hierarchical_2d.sh completed — 3D result is compared against 2D.
+#   5. Optional: run_hierarchical_2d.sh completed for a diagnostic comparison.
 #
 # Output: results/hierarchical/lucky_strikes_zform/nuts/lvk_farr/
 #   (same structure as 2D output — see run_hierarchical_2d.sh)
@@ -31,6 +32,7 @@
 #   NUM_CHAINS=4          independent chains (need >= 2 for R-hat)
 #   N_SAMPLES=10000       per-event importance sampling draws
 #   LVK_N_FOUND_MAX=5000  LVK injections for K matrix
+#   ALLOW_INCONSISTENT_SELECTION_MODEL=False  set True only for intentional legacy diagnostics
 # =============================================================================
 
 set -euo pipefail
@@ -54,6 +56,7 @@ NUM_SAMPLES="${NUM_SAMPLES:-1000}"
 NUM_CHAINS="${NUM_CHAINS:-4}"
 N_SAMPLES="${N_SAMPLES:-10000}"
 LVK_N_FOUND_MAX="${LVK_N_FOUND_MAX:-5000}"
+ALLOW_INCONSISTENT_SELECTION_MODEL="${ALLOW_INCONSISTENT_SELECTION_MODEL:-False}"  # explicit legacy/diagnostic override
 
 OUTPUT_DIR="${RESULTS_ROOT}/hierarchical/${CONFIG_NAME}/nuts/lvk_farr"
 DIR_2D="${RESULTS_ROOT}/hierarchical/lucky_strikes/nuts/lvk_farr"
@@ -104,6 +107,87 @@ for f in "${INJECTIONS_PATH}" "${LVK_FOUND_PATH}"; do
     fi
 done
 
+# Validate mode metadata and required fields before launching an expensive run.
+echo ""
+echo ">>> Checking event/injection metadata consistency..."
+python - "${RESULTS_ROOT}" "${CONFIG_NAME}" "${INJECTIONS_PATH}" "${LVK_FOUND_PATH}" "${ALLOW_INCONSISTENT_SELECTION_MODEL}" "3D" <<'PY'
+import glob
+import os
+import sys
+import numpy as np
+
+results_root, config_name, injections_path, lvk_found_path, allow_raw, expected_mode = sys.argv[1:7]
+allow = str(allow_raw).strip().lower() in {"1", "true", "yes", "y"}
+expected_3d = expected_mode == "3D"
+required_event_keys = {"params_in", "lower_bound", "upper_bound", "event_name", "likelihood_mode", "uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"}
+required_event_files = {"points.npy", "log_w.npy", "log_z.npy", "metadata.npz"}
+required_injection_keys = {"theta", "m1_src", "m2_src", "z_merger", "params", "lower_bound", "upper_bound", "N_inj", "N_merge", "likelihood_mode", "uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"}
+
+def fail(msg):
+    if allow:
+        print(f"OVERRIDE WARNING: {msg}")
+    else:
+        print(f"ERROR: {msg}")
+        print("Set ALLOW_INCONSISTENT_SELECTION_MODEL=True only for an intentional legacy/diagnostic override.")
+        sys.exit(1)
+
+def scalar(npz, key):
+    val = npz[key]
+    if getattr(val, "shape", ()) == ():
+        return val.item()
+    if val.size == 1:
+        item = val.ravel()[0]
+        return item.item() if hasattr(item, "item") else item
+    return val
+
+def as_bool(x):
+    if isinstance(x, (bool, np.bool_)):
+        return bool(x)
+    return str(x).strip().lower() in {"1", "true", "yes", "y"}
+
+if not injections_path or not lvk_found_path:
+    fail("Selection correction is not enabled: both INJECTIONS_PATH and LVK_FOUND_PATH are required by this workflow script.")
+for path, label in [(injections_path, "injection NPZ"), (lvk_found_path, "LVK found injection file")]:
+    if not os.path.isfile(path):
+        print(f"ERROR: Missing {label}: {path}")
+        sys.exit(1)
+
+event_dirs = sorted(os.path.dirname(p) for p in glob.glob(os.path.join(results_root, "*", config_name, "log_z.npy")))
+if len(event_dirs) < 2:
+    print(f"ERROR: Need at least 2 completed {config_name} events; found {len(event_dirs)}.")
+    sys.exit(1)
+
+for d in event_dirs:
+    missing_files = sorted(f for f in required_event_files if not os.path.isfile(os.path.join(d, f)))
+    if missing_files:
+        print(f"ERROR: Event directory {d} is missing required files: {missing_files}")
+        sys.exit(1)
+    meta = np.load(os.path.join(d, "metadata.npz"), allow_pickle=True)
+    missing_keys = sorted(required_event_keys - set(meta.files))
+    if missing_keys:
+        fail(f"Event metadata {d}/metadata.npz is missing mode/required keys: {missing_keys}")
+        continue
+    mode = str(scalar(meta, "likelihood_mode")).upper()
+    flags = {k: as_bool(scalar(meta, k)) for k in ["uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"]}
+    if mode != expected_mode or any(v != expected_3d for v in flags.values()):
+        fail(f"Event metadata in {d} does not match {expected_mode}: likelihood_mode={mode}, flags={flags}")
+
+inj = np.load(injections_path, allow_pickle=True)
+missing_inj = sorted(required_injection_keys - set(inj.files))
+if missing_inj:
+    fail(f"Injection metadata/file is missing required keys: {missing_inj}")
+else:
+    inj_mode = str(scalar(inj, "likelihood_mode")).upper()
+    inj_flags = {k: as_bool(scalar(inj, k)) for k in ["uses_z_form", "uses_sfr_prior", "uses_logZ_given_z_prior"]}
+    if inj_mode != expected_mode or any(v != expected_3d for v in inj_flags.values()):
+        fail(f"Injection metadata does not match {expected_mode}: likelihood_mode={inj_mode}, flags={inj_flags}")
+    if int(np.ravel(inj["N_merge"])[0]) <= 0 or len(inj["z_merger"]) == 0:
+        print("ERROR: Injection catalog has no merging/redshift samples for selection correction.")
+        sys.exit(1)
+
+print(f"Metadata preflight OK: {len(event_dirs)} {expected_mode} events, matching {expected_mode} injections, LVK/Farr selection enabled.")
+PY
+
 # Check for 2D results to compare against
 echo ""
 if [ -f "${DIR_2D}/summary.csv" ]; then
@@ -133,6 +217,7 @@ python hierarchical_backpop_jax.py \
     --num_samples       "${NUM_SAMPLES}" \
     --num_chains        "${NUM_CHAINS}" \
     --lvk_n_found_max   "${LVK_N_FOUND_MAX}" \
+    --allow_inconsistent_selection_model "${ALLOW_INCONSISTENT_SELECTION_MODEL}" \
     2>&1 | tee "${OUTPUT_DIR}/run.log"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Production selection-corrected hierarchical inference should prefer the 3D event/injection model because selection effects depend on mass and redshift. 
- 2D runs are useful for quick diagnostics and comparisons to Lucky Strikes but must be explicitly flagged as diagnostic unless paired with a self-consistent 2D injection campaign. 
- Workflow scripts need stronger preflight guardrails to prevent accidental, inconsistent, or selection-disabled production runs. 

### Description
- Marked `run_hierarchical_3d.sh` as the recommended production workflow and clarified `run_hierarchical_2d.sh` as a diagnostic/comparison workflow in the header comments. 
- Added loud metadata/integrity preflight checks to both `run_hierarchical_3d.sh` and `run_hierarchical_2d.sh` that validate the presence of required event files/fields, injection catalog fields, that selection correction inputs (`INJECTIONS_PATH` and `LVK_FOUND_PATH`) are provided, and that likelihood-mode metadata matches the script mode. 
- Scripts now fail loudly on missing or inconsistent mode metadata unless an explicit override is set via `ALLOW_INCONSISTENT_SELECTION_MODEL=True`, and the override is passed through to `hierarchical_backpop_jax.py` as `--allow_inconsistent_selection_model`. 
- Added `WORKFLOWS.md` documenting recommended workflows: production 3D (end-to-end), fast diagnostic 2D, no-selection smoke test, and selection-estimator comparison. 
- Kept the existing command-line interface intact by forwarding the explicit inconsistent-selection override to the Python driver and not changing existing argument names. 

### Testing
- Ran `pytest tests/test_selection_model_consistency.py tests/test_selection_mode.py`, all tests passed (`6 passed, 1 warning`). 
- Performed shell syntax checks with `bash -n run_hierarchical_3d.sh` and `bash -n run_hierarchical_2d.sh`, both succeeded. 
- Ran repository checks (`git diff --check`) and basic automated validations; no syntax issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef5ff4564832baca472f7d157f3cc)