### PR TITLE
Align JAX Maxwell boundary clipping with NumPy

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -194,7 +194,7 @@ def maxwell_logpdf(x: jnp.ndarray, scale: float | jnp.ndarray) -> jnp.ndarray:
 
     Validated against scipy.stats.maxwell.logpdf(x, scale=sigma).
     """
-    x_safe = jnp.clip(x, 1e-30, None)
+    x_safe = jnp.clip(x, 1e-300, None)
     return (
         0.5 * jnp.log(2.0 / jnp.pi)
         + 2.0 * jnp.log(x_safe)


### PR DESCRIPTION
### Motivation
- Fix numeric mismatch between the JAX and NumPy implementations of the truncated Maxwell density at the zero boundary so `log_p_vk_jax` matches `_maxwell_logpdf_numpy` for `vk=0`.

### Description
- Change the lower clipping floor in `maxwell_logpdf` from `1e-30` to `1e-300` in `hierarchical_backpop_jax.py` so JAX uses the same tiny floor as the NumPy implementation when computing `x_safe`.

### Testing
- Successfully ran syntax check with `python -m py_compile hierarchical_backpop_jax.py` which passed.
- Ran `git diff --check` which reported no trailing whitespace or diff issues; attempted `pytest tests/test_truncated_population_densities.py -q` but tests could not be executed because the active Python environments lacked `numpy` (attempts with `PYENV_VERSION=3.11.15` also failed for the same reason).
- Attempted to install test dependencies via `python -m pip install -e '.[test]'` but installation failed due to inability to fetch build dependencies from the package index (network error `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3efa5b6750832ba54e527527a9c012)