### PR TITLE
Add experimental emulator prototype for emulator-based selection

### DIFF
--- a/experimental/emulator/README.md
+++ b/experimental/emulator/README.md
@@ -1,0 +1,71 @@
+# Experimental emulator BackPop prototype
+
+**Status: experimental only. Do not use this path for production inference.**
+
+This directory sketches an emulator-based hierarchical BackPop workflow that is intentionally separate from the production scripts. The prototype is a sandbox for replacing finite-COSMIC-catalog KDE selection estimates with a fast conditional density model for
+
+```math
+p(m_c, q, z_\mathrm{merge}, \theta_\mathrm{latent} \mid \Lambda),
+```
+
+where `\Lambda` denotes population hyperparameters or binary-physics controls and `\theta_\mathrm{latent}` denotes additional simulated latent quantities that future analyses may need for reweighting or diagnostics.
+
+The current implementation is deliberately simple: it uses a conditional Gaussian placeholder, not a validated astrophysical model. The API is designed so a future neural spline flow, density-ratio estimator, or simulation-based inference model can replace the placeholder without changing downstream selection-code call sites.
+
+## What is included
+
+- `api.py` defines the experimental API:
+  - generate a COSMIC-style injection catalog (`generate_cosmic_injection_catalog`),
+  - load an injection catalog (`load_cosmic_injection_catalog`),
+  - featurize hyperparameters (`featurize_hyperparameters`),
+  - train a conditional density emulator (`GaussianConditionalEmulator.fit`),
+  - sample predicted merger observables (`sample_predicted_mergers`),
+  - estimate selection `alpha` from a user-supplied `pdet` function (`estimate_selection_alpha`).
+- `toy_emulator_demo.py` runs the workflow on fake data when real COSMIC data are unavailable.
+
+## Minimal workflow
+
+```bash
+python experimental/emulator/toy_emulator_demo.py --output-dir /tmp/backpop-emulator-demo
+```
+
+The toy script writes a fake catalog, fits the placeholder emulator, samples predicted mergers at a target `\Lambda`, and estimates
+
+```math
+\alpha(\Lambda) \approx \frac{1}{N}\sum_j p_\mathrm{det}(m_{c,j}, q_j, z_j).
+```
+
+## Catalog schema
+
+The loader expects `.npz` files with at least these arrays:
+
+| Field | Meaning |
+| --- | --- |
+| `lambda_features` | Two-dimensional array of hyperparameter or binary-physics features. |
+| `observables` | Two-dimensional array of simulated outputs. Defaults to columns `(mc, q, z_merge, theta_latent)`. |
+
+Optional arrays:
+
+| Field | Meaning |
+| --- | --- |
+| `lambda_names` | Names for columns in `lambda_features`. |
+| `observable_names` | Names for columns in `observables`. |
+| `metadata` | JSON metadata string. |
+
+## Production warnings
+
+- This module is not imported by production BackPop entry points.
+- The Gaussian placeholder is not a validated conditional density estimate.
+- The toy `pdet` function is not a detector-selection model.
+- Real analyses must track the COSMIC proposal density, failed simulations, merger cuts, cosmology, PE priors, and detector-frame/source-frame conventions.
+- Selection estimates from this prototype should be treated as API tests and diagnostics only.
+
+## Actions needed before package integration
+
+1. Define a versioned COSMIC simulation schema with explicit proposal densities and failed-run accounting.
+2. Generate training grids over the actual hierarchical hyperparameters `\Lambda` used by `hierarchical_backpop_jax.py`.
+3. Replace the placeholder Gaussian with a validated conditional density model, such as a neural spline flow or density-ratio estimator.
+4. Add calibration diagnostics: posterior predictive checks, coverage tests, held-out likelihoods, and comparisons against direct COSMIC KDE estimates.
+5. Thread the emulator through a new, opt-in hierarchical-selection code path without changing existing production defaults.
+6. Validate `\alpha(\Lambda)` against LVK/Farr found-injection estimates and direct `pdet` campaigns on shared benchmark catalogs.
+7. Add CI tests that use tiny deterministic fake catalogs and separate long-running COSMIC integration tests behind an optional marker.

--- a/experimental/emulator/__init__.py
+++ b/experimental/emulator/__init__.py
@@ -1,0 +1,24 @@
+"""Experimental emulator-based BackPop selection prototype.
+
+This package is intentionally outside the production BackPop import path.
+"""
+
+from .api import (
+    CosmicInjectionCatalog,
+    GaussianConditionalEmulator,
+    estimate_selection_alpha,
+    featurize_hyperparameters,
+    generate_cosmic_injection_catalog,
+    load_cosmic_injection_catalog,
+    sample_predicted_mergers,
+)
+
+__all__ = [
+    "CosmicInjectionCatalog",
+    "GaussianConditionalEmulator",
+    "estimate_selection_alpha",
+    "featurize_hyperparameters",
+    "generate_cosmic_injection_catalog",
+    "load_cosmic_injection_catalog",
+    "sample_predicted_mergers",
+]

--- a/experimental/emulator/api.py
+++ b/experimental/emulator/api.py
@@ -1,0 +1,200 @@
+"""Experimental conditional-density API for emulator-based BackPop selection.
+
+The classes and functions in this module are prototypes. They are not used by
+the production BackPop scripts and are not validated for astrophysical
+inference. The placeholder density model is intentionally simple so future work
+can swap in a neural spline flow or density-ratio estimator behind the same
+interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, Sequence
+
+import numpy as np
+
+DEFAULT_LAMBDA_NAMES = ("alpha_ce", "f_acc", "sigma_kick")
+DEFAULT_OBSERVABLE_NAMES = ("mc", "q", "z_merge", "theta_latent")
+
+
+@dataclass(frozen=True)
+class CosmicInjectionCatalog:
+    """Container for COSMIC-style emulator training data."""
+
+    lambda_features: np.ndarray
+    observables: np.ndarray
+    lambda_names: tuple[str, ...] = DEFAULT_LAMBDA_NAMES
+    observable_names: tuple[str, ...] = DEFAULT_OBSERVABLE_NAMES
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        lambda_features = np.asarray(self.lambda_features, dtype=float)
+        observables = np.asarray(self.observables, dtype=float)
+        if lambda_features.ndim != 2:
+            raise ValueError("lambda_features must be a two-dimensional array")
+        if observables.ndim != 2:
+            raise ValueError("observables must be a two-dimensional array")
+        if len(lambda_features) != len(observables):
+            raise ValueError("lambda_features and observables must have the same row count")
+        if lambda_features.shape[1] != len(self.lambda_names):
+            raise ValueError("lambda_names length must match lambda_features columns")
+        if observables.shape[1] != len(self.observable_names):
+            raise ValueError("observable_names length must match observables columns")
+        object.__setattr__(self, "lambda_features", lambda_features)
+        object.__setattr__(self, "observables", observables)
+
+    def save_npz(self, path: str | Path) -> None:
+        """Write the catalog to a compact `.npz` file."""
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(
+            path,
+            lambda_features=self.lambda_features,
+            observables=self.observables,
+            lambda_names=np.asarray(self.lambda_names),
+            observable_names=np.asarray(self.observable_names),
+            metadata=json.dumps(dict(self.metadata or {})),
+        )
+
+
+class ConditionalDensityEmulator(Protocol):
+    """Interface future density estimators should implement."""
+
+    observable_names: tuple[str, ...]
+
+    def sample(
+        self,
+        lambda_features: Sequence[float] | np.ndarray,
+        n_samples: int,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        """Draw observables from p(observables | Lambda)."""
+
+
+def featurize_hyperparameters(
+    hyperparameters: Mapping[str, float],
+    names: Sequence[str] = DEFAULT_LAMBDA_NAMES,
+) -> np.ndarray:
+    """Convert named hyperparameters into a stable numeric feature vector."""
+
+    missing = [name for name in names if name not in hyperparameters]
+    if missing:
+        raise KeyError(f"Missing hyperparameters: {missing}")
+    return np.asarray([hyperparameters[name] for name in names], dtype=float)
+
+
+def load_cosmic_injection_catalog(path: str | Path) -> CosmicInjectionCatalog:
+    """Load a COSMIC-style emulator catalog from `.npz`.
+
+    Real COSMIC catalogs should be converted into this schema before training.
+    """
+
+    with np.load(path, allow_pickle=False) as data:
+        metadata_raw = str(data["metadata"]) if "metadata" in data else "{}"
+        return CosmicInjectionCatalog(
+            lambda_features=data["lambda_features"],
+            observables=data["observables"],
+            lambda_names=tuple(str(x) for x in (data["lambda_names"] if "lambda_names" in data else DEFAULT_LAMBDA_NAMES)),
+            observable_names=tuple(str(x) for x in (data["observable_names"] if "observable_names" in data else DEFAULT_OBSERVABLE_NAMES)),
+            metadata=json.loads(metadata_raw),
+        )
+
+
+def generate_cosmic_injection_catalog(
+    path: str | Path,
+    n_simulations: int = 2_000,
+    rng: np.random.Generator | None = None,
+) -> CosmicInjectionCatalog:
+    """Generate a fake COSMIC-like catalog for emulator API development.
+
+    This is a deterministic toy stand-in, not a COSMIC runner. Replace this
+    function with a wrapper around `cosmic-popsynth` for real training data.
+    """
+
+    rng = np.random.default_rng() if rng is None else rng
+    alpha_ce = rng.uniform(0.2, 5.0, n_simulations)
+    f_acc = rng.uniform(0.05, 0.95, n_simulations)
+    sigma_kick = rng.uniform(20.0, 300.0, n_simulations)
+    lambda_features = np.column_stack([alpha_ce, f_acc, sigma_kick])
+
+    mc = 12.0 + 5.5 * np.log1p(alpha_ce) + 10.0 * f_acc + rng.normal(0.0, 2.0, n_simulations)
+    q = np.clip(0.35 + 0.45 * f_acc - 0.0005 * sigma_kick + rng.normal(0.0, 0.08, n_simulations), 0.05, 1.0)
+    z_merge = np.clip(0.05 + 0.04 * alpha_ce + 0.0015 * sigma_kick + rng.normal(0.0, 0.05, n_simulations), 0.0, None)
+    theta_latent = rng.normal(np.log1p(alpha_ce) - f_acc, 0.3, n_simulations)
+    observables = np.column_stack([mc, q, z_merge, theta_latent])
+
+    catalog = CosmicInjectionCatalog(
+        lambda_features=lambda_features,
+        observables=observables,
+        metadata={"warning": "fake COSMIC-like data for emulator prototyping only"},
+    )
+    catalog.save_npz(path)
+    return catalog
+
+
+@dataclass
+class GaussianConditionalEmulator:
+    """Linear-mean multivariate Gaussian placeholder emulator."""
+
+    coefficients: np.ndarray
+    residual_covariance: np.ndarray
+    lambda_names: tuple[str, ...] = DEFAULT_LAMBDA_NAMES
+    observable_names: tuple[str, ...] = DEFAULT_OBSERVABLE_NAMES
+
+    @classmethod
+    def fit(cls, catalog: CosmicInjectionCatalog, ridge: float = 1.0e-6) -> "GaussianConditionalEmulator":
+        design = np.column_stack([np.ones(len(catalog.lambda_features)), catalog.lambda_features])
+        coefficients, *_ = np.linalg.lstsq(design, catalog.observables, rcond=None)
+        residuals = catalog.observables - design @ coefficients
+        covariance = np.cov(residuals, rowvar=False) + ridge * np.eye(catalog.observables.shape[1])
+        return cls(coefficients, covariance, catalog.lambda_names, catalog.observable_names)
+
+    def sample(
+        self,
+        lambda_features: Sequence[float] | np.ndarray,
+        n_samples: int,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        rng = np.random.default_rng() if rng is None else rng
+        features = np.asarray(lambda_features, dtype=float)
+        if features.shape != (len(self.lambda_names),):
+            raise ValueError(f"Expected {len(self.lambda_names)} lambda features, got shape {features.shape}")
+        mean = np.r_[1.0, features] @ self.coefficients
+        draws = rng.multivariate_normal(mean, self.residual_covariance, size=n_samples)
+        draws[:, self.observable_names.index("q")] = np.clip(draws[:, self.observable_names.index("q")], 0.0, 1.0)
+        draws[:, self.observable_names.index("z_merge")] = np.clip(draws[:, self.observable_names.index("z_merge")], 0.0, None)
+        return draws
+
+
+def sample_predicted_mergers(
+    emulator: ConditionalDensityEmulator,
+    hyperparameters: Mapping[str, float],
+    n_samples: int,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Sample emulator-predicted merger observables for named hyperparameters."""
+
+    features = featurize_hyperparameters(hyperparameters)
+    return emulator.sample(features, n_samples=n_samples, rng=rng)
+
+
+def estimate_selection_alpha(
+    emulator: ConditionalDensityEmulator,
+    hyperparameters: Mapping[str, float],
+    pdet: Callable[[np.ndarray], np.ndarray],
+    n_samples: int = 10_000,
+    rng: np.random.Generator | None = None,
+) -> float:
+    """Estimate detectable fraction from emulator samples and a pdet callable."""
+
+    samples = sample_predicted_mergers(emulator, hyperparameters, n_samples, rng=rng)
+    probabilities = np.asarray(pdet(samples), dtype=float)
+    if probabilities.shape != (n_samples,):
+        raise ValueError("pdet must return one probability per emulator sample")
+    if np.any((probabilities < 0.0) | (probabilities > 1.0)):
+        raise ValueError("pdet probabilities must lie in [0, 1]")
+    return float(np.mean(probabilities))

--- a/experimental/emulator/toy_emulator_demo.py
+++ b/experimental/emulator/toy_emulator_demo.py
@@ -1,0 +1,83 @@
+"""Toy emulator workflow using fake COSMIC-like data.
+
+Run from the repository root:
+
+    python experimental/emulator/toy_emulator_demo.py --output-dir /tmp/backpop-emulator-demo
+
+This script is experimental and is not a production inference workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from .api import (
+        GaussianConditionalEmulator,
+        estimate_selection_alpha,
+        generate_cosmic_injection_catalog,
+        load_cosmic_injection_catalog,
+        sample_predicted_mergers,
+    )
+except ImportError:  # Allows direct execution as a script from the repo root.
+    from api import (  # type: ignore[no-redef]
+        GaussianConditionalEmulator,
+        estimate_selection_alpha,
+        generate_cosmic_injection_catalog,
+        load_cosmic_injection_catalog,
+        sample_predicted_mergers,
+    )
+
+
+def toy_pdet(observables: np.ndarray) -> np.ndarray:
+    """Smooth fake detection probability for API testing only."""
+
+    mc = observables[:, 0]
+    q = observables[:, 1]
+    z_merge = observables[:, 2]
+    mass_term = 1.0 / (1.0 + np.exp(-(mc - 22.0) / 4.0))
+    redshift_term = np.exp(-1.5 * z_merge)
+    mass_ratio_term = np.clip(q, 0.0, 1.0) ** 0.5
+    return np.clip(mass_term * redshift_term * mass_ratio_term, 0.0, 1.0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=Path("experimental/emulator/_toy_output"))
+    parser.add_argument("--n-training", type=int, default=2_000)
+    parser.add_argument("--n-selection-samples", type=int, default=5_000)
+    parser.add_argument("--seed", type=int, default=1234)
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    catalog_path = args.output_dir / "fake_cosmic_catalog.npz"
+
+    generate_cosmic_injection_catalog(catalog_path, n_simulations=args.n_training, rng=rng)
+    catalog = load_cosmic_injection_catalog(catalog_path)
+    emulator = GaussianConditionalEmulator.fit(catalog)
+
+    target_lambda = {"alpha_ce": 1.5, "f_acc": 0.4, "sigma_kick": 120.0}
+    predicted = sample_predicted_mergers(emulator, target_lambda, n_samples=5, rng=rng)
+    alpha = estimate_selection_alpha(
+        emulator,
+        target_lambda,
+        toy_pdet,
+        n_samples=args.n_selection_samples,
+        rng=rng,
+    )
+
+    print("WARNING: experimental emulator prototype; not production inference.")
+    print(f"Wrote fake catalog: {catalog_path}")
+    print(f"Catalog rows: {len(catalog.observables)}")
+    print(f"Observable columns: {catalog.observable_names}")
+    print("First five predicted mergers at target Lambda:")
+    print(predicted)
+    print(f"Toy selection alpha: {alpha:.6f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide an isolated experimental scaffold for emulator-based hierarchical BackPop selection that models p(mc, q, z_merge, theta_latent | Lambda) and can be swapped into future pipelines without touching production code. 
- Keep the implementation intentionally simple (Gaussian placeholder) so the API can be validated and replaced later with neural spline flows or density-ratio estimators. 
- Give a minimal end-to-end developer path: generate/load COSMIC-like catalogs, featurize hyperparameters, fit a conditional emulator, draw predicted mergers, and estimate selection alpha via a user-supplied `pdet` callable. 

### Description

- Add `experimental/emulator/` containing `README.md` that documents experimental status, catalog schema, production warnings, and actions required for package integration. 
- Implement `experimental/emulator/api.py` which provides `CosmicInjectionCatalog`, `featurize_hyperparameters`, `load_cosmic_injection_catalog`, `generate_cosmic_injection_catalog`, a `ConditionalDensityEmulator` protocol, a `GaussianConditionalEmulator` placeholder with `fit`/`sample`, `sample_predicted_mergers`, and `estimate_selection_alpha`. 
- Add a thin package export `experimental/emulator/__init__.py` and a toy driver `experimental/emulator/toy_emulator_demo.py` that exercises the API with fake data and a toy smooth `pdet` function. 
- Ensure no production entry points or existing BackPop modules are modified, and the new module is intentionally outside the production import path. 

### Testing

- Ran Python byte-compile on the new modules with `python -m py_compile experimental/emulator/api.py experimental/emulator/toy_emulator_demo.py`, which succeeded. 
- Attempted to run the demo `python experimental/emulator/toy_emulator_demo.py --output-dir /tmp/backpop-emulator-demo --n-training 100 --n-selection-samples 200`, which failed in this environment due to missing runtime dependency `numpy` (not a code error in the prototype).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3efb150cdc832b9e4200f507cf926e)