### PR TITLE
Return mutable default hyperparameter vector

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -168,7 +168,11 @@ def default_hyperparams(as_vector: bool = True):
     """
     values = {p["name"]: float(p["default"]) for p in HYPERPARAM_INFO}
     if as_vector:
-        return jnp.array([values[name] for name in POP_PARAM_NAMES], dtype=jnp.float64)
+        # Return a NumPy array rather than a JAX array so callers can freely
+        # make mutable NumPy views/copies when perturbing the initialization
+        # point in tests or diagnostics.  JAX-compiled likelihood helpers
+        # accept this array-like input and convert it as needed.
+        return np.array([values[name] for name in POP_PARAM_NAMES], dtype=np.float64)
     return values
 
 


### PR DESCRIPTION
### Motivation
- Tests attempted to perturb the vector returned by `default_hyperparams()` and hit `ValueError: assignment destination is read-only` when callers wrapped the JAX array with `np.asarray(..., dtype=float)`, so the initialization vector should be returned as a mutable NumPy array to allow in-place edits in tests/diagnostics.

### Description
- Change `default_hyperparams(as_vector=True)` to return a `np.array([...], dtype=np.float64)` instead of a `jnp.array`, and add a brief comment explaining that the NumPy array is returned to permit mutable views while remaining array-like for JAX helpers.

### Testing
- Ran `python -m py_compile hierarchical_backpop_jax.py`, which succeeded. 
- Attempted `pytest tests/test_lightweight_infrastructure.py::test_toy_hierarchical_likelihood_prefers_matching_population tests/test_default_hyperparams.py`, but the run aborted with `ModuleNotFoundError: No module named 'numpy'` in the local environment so full test verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f074be4a0832bbf177c71e8655ea5)