### PR TITLE
Accept and enforce config-derived `logZ_support` in 3D likelihood and add regression test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Smoke-test non-COSMIC imports
         run: python smoke_test_imports.py --skip-cosmic
       - name: Run lightweight tests
-        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py
+        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py tests/test_injection_proposal.py

--- a/run_backpop.py
+++ b/run_backpop.py
@@ -219,6 +219,8 @@ def likelihood_2d(
         Support policy applied consistently to KDE observables.
     fixed_params : dict
         Fixed COSMIC parameters.  Bound via partial.
+    logZ_support : tuple[float, float]
+        Active BackPop configuration support for log10 metallicity.
 
     Returns
     -------
@@ -260,6 +262,7 @@ def likelihood_3d(
     z_bounds: tuple[float, float],
     support_gate: str,
     fixed_params: dict,
+    logZ_support: tuple[float, float],
 ) -> tuple[float, np.ndarray, np.ndarray]:
     """Log-likelihood for the 3D (mc, q, z_merger) KDE mode.
 
@@ -296,12 +299,18 @@ def likelihood_3d(
         Support policy applied consistently to KDE observables.
     fixed_params : dict
         Fixed COSMIC parameters.  Bound via partial.
+    logZ_support : tuple[float, float]
+        Active BackPop configuration support for log10 metallicity.
 
     Returns
     -------
     log_prob, bpp_flat, kick_flat
     """
     nan_bpp, nan_kick = _nan_blobs()
+
+    logZ_lo, logZ_hi = map(float, logZ_support)
+    if not logZ_lo < logZ_hi:
+        raise ValueError("logZ_support must satisfy lo < hi")
 
     z_form  = params_in.get('z_form')
     log10_Z = params_in.get('logZ')
@@ -317,7 +326,7 @@ def likelihood_3d(
     if not np.isfinite(lp_z):
         return -np.inf, nan_bpp, nan_kick
 
-    lp_logZ = log_prior_logZ_given_z_on_support(log10_Z, z_form, logZ_support[0], logZ_support[1])
+    lp_logZ = log_prior_logZ_given_z_on_support(log10_Z, z_form, logZ_lo, logZ_hi)
     if not np.isfinite(lp_logZ):
         return -np.inf, nan_bpp, nan_kick
 
@@ -521,6 +530,10 @@ def main():
             mc_bounds=mc_bounds,
             support_gate=opts.support_gate,
             fixed_params=fixed_params,
+            logZ_support=(
+                float(lower_bound[params_in_names.index("logZ")]),
+                float(upper_bound[params_in_names.index("logZ")]),
+            ),
         )
 
     # ---- Nautilus sampler ----

--- a/tests/test_injection_proposal.py
+++ b/tests/test_injection_proposal.py
@@ -128,3 +128,82 @@ def test_3d_logz_proposal_and_static_numerator_use_same_config_support():
         )
     finally:
         ri.LIKELIHOOD_MODE, ri.LOGZ_LO, ri.LOGZ_HI = old_mode, old_lo, old_hi
+
+
+def test_likelihood_3d_accepts_config_logz_support(monkeypatch):
+    import importlib
+    import sys
+    import types
+
+    class FakeKDE:
+        def logpdf(self, coord):
+            return np.array([0.0])
+
+    fake_nautilus = types.ModuleType("nautilus")
+    fake_nautilus.Prior = object
+    fake_nautilus.Sampler = object
+    monkeypatch.setitem(sys.modules, "nautilus", fake_nautilus)
+
+    fake_backpop = types.ModuleType("backpop")
+    fake_backpop.get_backpop_config = lambda name: None
+    fake_backpop.load_gw_data = lambda *args, **kwargs: None
+    fake_backpop.evolv2 = lambda *args, **kwargs: None
+    fake_backpop.str_to_bool = lambda value: value
+    fake_backpop.BPP_SHAPE = (1,)
+    fake_backpop.KICK_SHAPE = (1,)
+    fake_backpop.COLS_KEEP = []
+    monkeypatch.setitem(sys.modules, "backpop", fake_backpop)
+
+    sys.modules.pop("run_backpop", None)
+    run_backpop = importlib.import_module("run_backpop")
+
+    monkeypatch.setattr(
+        run_backpop,
+        "evolv2",
+        lambda params, output_columns, fixed_params: (
+            {"mass_1": 30.0, "mass_2": 20.0},
+            np.array([1.0]),
+            np.array([2.0]),
+        ),
+    )
+    monkeypatch.setattr(run_backpop, "_extract_t_delay_myr", lambda bpp_raw: 100.0)
+    monkeypatch.setattr(run_backpop, "z_merger_from_t_delay", lambda z_form, t_delay: 0.1)
+
+    log_prob, bpp_flat, kick_flat = run_backpop.likelihood_3d(
+        {"z_form": 1.0, "logZ": -2.0},
+        kde=FakeKDE(),
+        q_bounds=(0.0, 1.0),
+        mc_bounds=(0.0, 100.0),
+        z_bounds=(0.0, 2.0),
+        support_gate="none",
+        fixed_params={},
+        logZ_support=(-4.0, 0.0),
+    )
+
+    assert np.isfinite(log_prob)
+    assert np.array_equal(bpp_flat, np.array([1.0]))
+    assert np.array_equal(kick_flat, np.array([2.0]))
+
+    log_prob, _, _ = run_backpop.likelihood_3d(
+        {"z_form": 1.0, "logZ": -5.0},
+        kde=FakeKDE(),
+        q_bounds=(0.0, 1.0),
+        mc_bounds=(0.0, 100.0),
+        z_bounds=(0.0, 2.0),
+        support_gate="none",
+        fixed_params={},
+        logZ_support=(-4.0, 0.0),
+    )
+    assert np.isneginf(log_prob)
+
+    with pytest.raises(ValueError, match="logZ_support must satisfy lo < hi"):
+        run_backpop.likelihood_3d(
+            {"z_form": 1.0, "logZ": -2.0},
+            kde=FakeKDE(),
+            q_bounds=(0.0, 1.0),
+            mc_bounds=(0.0, 100.0),
+            z_bounds=(0.0, 2.0),
+            support_gate="none",
+            fixed_params={},
+            logZ_support=(0.0, -4.0),
+        )


### PR DESCRIPTION
### Motivation

- The 3D single-event likelihood was being passed a `logZ_support` tuple via `functools.partial()` but `likelihood_3d()` did not accept it, causing runtime failures; the goal is to ensure the single-event likelihood, injection proposal, and static numerator all use the same active BackPop metallicity support.

### Description

- Updated `likelihood_3d()` to accept a keyword-only `logZ_support: tuple[float, float]` parameter and added a docstring entry for it. 
- Added validation at the top of `likelihood_3d()` that maps `logZ_support` to `logZ_lo, logZ_hi`, and raises `ValueError` when `logZ_lo >= logZ_hi`.
- Use `logZ_lo` and `logZ_hi` when calling `log_prior_logZ_given_z_on_support()` so the 3D likelihood uses the active config-derived metallicity support. 
- Bind `logZ_support` into the `functools.partial()` likelihood construction so the single-event run passes the config-derived support into the likelihood callable. 
- Added a lightweight regression test `test_likelihood_3d_accepts_config_logz_support` in `tests/test_injection_proposal.py` that monkeypatches/stubs Nautilus and COSMIC-facing pieces, uses a fake `KDE`, and asserts finite in-support behavior, out-of-support rejection, and invalid-support validation. 
- Included `tests/test_injection_proposal.py` in the lightweight GitHub Actions pytest command in `.github/workflows/tests.yml`.

### Testing

- Performed a syntax/AST check with `ast.parse` on `run_backpop.py` and `tests/test_injection_proposal.py`, which succeeded. 
- Attempted to install test dependencies with `python -m pip install -e '.[test]'`, but dependency installation failed in this environment due to package-index access errors (blocked by network/Tunnel 403). 
- Ran the lightweight `pytest` invocation including the new test, but collection failed in this environment because `numpy` was not available; the added test is designed to run without COSMIC but still requires the test deps in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0aec0af8832bb83e54cb5fabb91e)