### PR TITLE
Make root compatibility wrappers importable and lazy-load CLI entrypoints

### DIFF
--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python
 """Compatibility wrapper. Prefer ``gwbackpop-run-hierarchical``."""
-from gwbackpop.cli.run_hierarchical import main
+from pathlib import Path
+import sys
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+def main(*args, **kwargs):
+    from gwbackpop.cli.run_hierarchical import main as _main
+
+    return _main(*args, **kwargs)
+
 
 if __name__ == "__main__":
     main()

--- a/plot_backpop.py
+++ b/plot_backpop.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python
 """Compatibility wrapper. Prefer ``gwbackpop-plot``."""
-from gwbackpop.cli.plot_backpop import main
+from pathlib import Path
+import sys
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+def main(*args, **kwargs):
+    from gwbackpop.cli.plot_backpop import main as _main
+
+    return _main(*args, **kwargs)
+
 
 if __name__ == "__main__":
     main()

--- a/run_backpop.py
+++ b/run_backpop.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """Compatibility wrapper. Prefer ``gwbackpop-run-event``."""
 import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
 
 from gwbackpop.inference import single_event as _single_event
 

--- a/run_injections.py
+++ b/run_injections.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python
 """Compatibility wrapper. Prefer ``gwbackpop-run-injections``."""
-from gwbackpop.cli.run_injections import main
+from pathlib import Path
+import sys
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+def main(*args, **kwargs):
+    from gwbackpop.cli.run_injections import main as _main
+
+    return _main(*args, **kwargs)
+
 
 if __name__ == "__main__":
     main()

--- a/smoke_test_imports.py
+++ b/smoke_test_imports.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python
 """Compatibility wrapper. Prefer ``gwbackpop-smoke-test``."""
-from gwbackpop.cli.smoke_test import main
+from pathlib import Path
+import sys
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+def main(*args, **kwargs):
+    from gwbackpop.cli.smoke_test import main as _main
+
+    return _main(*args, **kwargs)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Root-level compatibility scripts should be importable when the repository is used directly rather than installed in editable mode. 
- Import-time failures occur when lightweight tests import these wrappers because optional runtime plotting/dependency packages (e.g., `seaborn`) are pulled in at module import time. 

### Description
- Add local `src` path bootstrapping (`Path(...)/src` inserted into `sys.path`) to each root compatibility wrapper to allow imports to resolve the package without installation. 
- Replace direct top-level imports of CLI entrypoints with lightweight `main` wrappers that perform the import lazily and delegate to the real `main`, avoiding heavy optional dependency imports during module import. 
- Applied the path-bootstrapping and lazy-import pattern to `run_backpop.py`, `plot_backpop.py`, `run_injections.py`, `hierarchical_backpop_jax.py`, and `smoke_test_imports.py`. 

### Testing
- Ran `python -m py_compile run_backpop.py run_injections.py hierarchical_backpop_jax.py plot_backpop.py smoke_test_imports.py`, which succeeded. 
- Ran `git diff --check` to validate no whitespace/format issues, which reported no problems. 
- Attempted to run the relevant pytest cases (`tests/test_lightweight_infrastructure.py::test_root_compatibility_wrappers_expose_main` and `tests/test_injection_proposal.py::test_likelihood_3d_accepts_config_logz_support`), but execution was blocked in the current environment because Python is missing `numpy`, so full pytest verification could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f36ab5408832b9b4b28cb3bf93712)