### PR TITLE
Restore legacy top-level `run_backpop` import and update tests for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,8 @@ markers = [
   "cosmic: tests that import or run COSMIC binary-evolution code",
 ]
 
+[tool.setuptools]
+py-modules = ["run_backpop"]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/run_backpop.py
+++ b/src/run_backpop.py
@@ -1,0 +1,15 @@
+"""Legacy import compatibility for :mod:`gwbackpop.inference.single_event`.
+
+Prefer the ``gwbackpop-run-event`` console script or
+``gwbackpop.inference.single_event`` for new code.  This module keeps existing
+``import run_backpop`` callers working when gwbackpop is installed as a package.
+"""
+from __future__ import annotations
+
+import sys
+
+from gwbackpop.inference import single_event as _single_event
+
+# Expose the implementation module itself so monkeypatching module globals such
+# as ``evolv2`` affects functions whose globals live in ``single_event``.
+sys.modules[__name__] = _single_event

--- a/tests/test_mass_frame_detection.py
+++ b/tests/test_mass_frame_detection.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def _load_mass_column_helpers():
-    source = Path(__file__).resolve().parents[1] / "backpop.py"
+    source = Path(__file__).resolve().parents[1] / "src" / "gwbackpop" / "evolution" / "cosmic.py"
     module_ast = ast.parse(source.read_text())
     wanted = {
         "_SOURCE_MASS_ALIASES",


### PR DESCRIPTION
### Motivation

- Preserve backwards compatibility for callers that import `run_backpop` after the repo was refactored to a `src/` layout. 
- Ensure tests that introspect legacy code continue to work against the refactored source tree.

### Description

- Add a `src/run_backpop.py` compatibility shim that aliases the top-level module to `gwbackpop.inference.single_event` by installing `sys.modules[__name__] = _single_event`, preserving the ability to monkeypatch module globals like `evolv2` used in tests. 
- Add `py-modules = ["run_backpop"]` to `pyproject.toml` so the legacy top-level module is packaged when installing the project in editable/test mode. 
- Update `tests/test_mass_frame_detection.py` to read the COSMIC backend source at `src/gwbackpop/evolution/cosmic.py` instead of the removed root `backpop.py` file.

### Testing

- Ran static compilation checks with `python -m py_compile run_backpop.py src/run_backpop.py src/gwbackpop/inference/single_event.py tests/test_mass_frame_detection.py`, which succeeded. 
- Attempted `pytest -q`, but test collection is blocked in this environment due to missing runtime dependency `numpy` (tests aborted with ModuleNotFoundError). 
- Attempted installing editable test extras with `python -m pip install -e '.[test]'`, but the environment failed to fetch build dependencies (network/package index returned 403), so an install-based test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3a6654dc832bae0063ff2104bf3d)