### PR TITLE
Use console entry points in docs and workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e '.[test]'
       - name: Smoke-test non-COSMIC imports
-        run: python smoke_test_imports.py --skip-cosmic
+        run: gwbackpop-smoke-test --skip-cosmic
+      - name: Smoke-test console entry points
+        run: |
+          gwbackpop-run-event --help
+          gwbackpop-run-injections --help
+          gwbackpop-run-hierarchical --help
+          gwbackpop-plot --help
+          gwbackpop-smoke-test --help
       - name: Run lightweight tests
-        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py tests/test_injection_proposal.py
+        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py tests/test_injection_proposal.py tests/test_cli_invocation_hygiene.py tests/test_console_entrypoints.py

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ The repository currently contains three main workflows. The installed console co
 
 | Workflow | Main entry point | Purpose | Status |
 |---|---|---|---|
-| Single-event 2D mass-only inference | `gwbackpop-run-event` (`python run_backpop.py` wrapper) | Infer binary-evolution parameters for one GW event using a KDE likelihood in source-frame chirp mass and mass ratio, `(\mathcal{M}_c, q)`. | **Production-ready baseline**. This is the most mature single-event mode. |
-| Single-event 3D mass-redshift inference | `gwbackpop-run-event --use_redshift_likelihood True` (`python run_backpop.py` wrapper) | Infer binary-evolution parameters for one GW event using `(\mathcal{M}_c, q, z_\mathrm{merger})` plus cosmological priors on formation redshift and metallicity. | **Production-ready if the PE samples and selection campaign are generated consistently**. Treat 2D/3D comparisons as model-dependent. |
-| Hierarchical population inference | `gwbackpop-run-hierarchical` (`python hierarchical_backpop_jax.py` wrapper) | Reweight per-event BackPop posteriors under a population hypermodel and optionally apply selection corrections. | **Production-ready only for the LVK/Farr found-injection selection estimator or explicit no-selection diagnostics**. Direct `pdet` hierarchical selection is not implemented in the JAX driver. |
+| Single-event 2D mass-only inference | `gwbackpop-run-event` | Infer binary-evolution parameters for one GW event using a KDE likelihood in source-frame chirp mass and mass ratio, `(\mathcal{M}_c, q)`. | **Production-ready baseline**. This is the most mature single-event mode. |
+| Single-event 3D mass-redshift inference | `gwbackpop-run-event --use_redshift_likelihood True` | Infer binary-evolution parameters for one GW event using `(\mathcal{M}_c, q, z_\mathrm{merger})` plus cosmological priors on formation redshift and metallicity. | **Production-ready if the PE samples and selection campaign are generated consistently**. Treat 2D/3D comparisons as model-dependent. |
+| Hierarchical population inference | `gwbackpop-run-hierarchical` | Reweight per-event BackPop posteriors under a population hypermodel and optionally apply selection corrections. | **Production-ready only for the LVK/Farr found-injection selection estimator or explicit no-selection diagnostics**. Direct `pdet` hierarchical selection is not implemented in the JAX driver. |
 
 Additional utilities:
 
-- `gwbackpop-run-injections` (`python run_injections.py`) builds COSMIC merger catalogs for selection corrections. It can either store a direct `P_det(m_1, m_2, z)` value from a pickled interpolator or store `pdet=nan` for the LVK/Farr workflow.
-- `gwbackpop-plot` (`python plot_backpop.py`) makes diagnostic figures from single-event output directories.
+- `gwbackpop-run-injections` builds COSMIC merger catalogs for selection corrections. It can either store a direct `P_det(m_1, m_2, z)` value from a pickled interpolator or store `pdet=nan` for the LVK/Farr workflow.
+- `gwbackpop-plot` makes diagnostic figures from single-event output directories.
 - `workflows/shell/run_hierarchical_2d.sh`, `workflows/shell/run_hierarchical_3d.sh`, and `workflows/slurm/run_catalog_gwtc3.slurm` are convenience wrappers for catalog-scale analyses.
+
+Legacy root-level Python wrappers may remain temporarily for backwards compatibility, but documented workflows and CI use the installed console commands.
 
 
 ## Repository layout
@@ -108,7 +110,7 @@ Z_i
 
 Here:
 
-- `Z_i` is the single-event evidence saved by `run_backpop.py` as `log_z.npy`.
+- `Z_i` is the single-event evidence saved by `gwbackpop-run-event` as `log_z.npy`.
 - `\langle\cdot\rangle_i` is an average over posterior samples for event `i`.
 - `p(\theta\mid\Lambda)` is the population model.
 - `\alpha(\Lambda)` is the detectable fraction under that population model.
@@ -138,7 +140,7 @@ Run `gwbackpop-run-hierarchical` without `--injections_path` and without `--lvk_
 
 ### 2. Direct `pdet` estimator
 
-`run_injections.py --pdet_path /path/to/pdet_interpolator.pkl` evaluates a user-provided callable `P_det(m1_src, m2_src, z_merger)` for each COSMIC merger and stores the result in the injection `.npz`. This is useful for building and auditing direct detection-probability campaigns.
+`gwbackpop-run-injections --pdet_path /path/to/pdet_interpolator.pkl` evaluates a user-provided callable `P_det(m1_src, m2_src, z_merger)` for each COSMIC merger and stores the result in the injection `.npz`. This is useful for building and auditing direct detection-probability campaigns.
 
 However, the current JAX hierarchical driver intentionally hard-errors if `--injections_path` is provided without `--lvk_found_path`, because the old direct-interpolator hierarchical path is not implemented there. Treat direct-`pdet` hierarchical selection as **not production-ready in this repository version** unless you add and validate that estimator yourself.
 
@@ -160,7 +162,7 @@ The production selection workflow uses COSMIC merger catalogs plus an LVK found-
 
 Use this mode by passing both:
 
-- `--injections_path`: COSMIC merger catalog from `run_injections.py`.
+- `--injections_path`: COSMIC merger catalog from `gwbackpop-run-injections`.
 - `--lvk_found_path`: LVK found-injection HDF5 containing source masses, redshift, and `sampling_pdf`.
 
 This is the **recommended production hierarchical mode**, subject to the caveats below.
@@ -184,7 +186,7 @@ Do not mix 2D event posteriors with 3D injection campaigns, or vice versa, unles
 
 ### PESummary GW posterior files
 
-`run_backpop.py --samples_path` expects a PESummary-compatible GW posterior file, usually HDF5. The code loads event posterior samples, builds a KDE in the requested coordinates, and uses the chosen approximant group, defaulting to `C01:Mixed`.
+`gwbackpop-run-event --samples_path` expects a PESummary-compatible GW posterior file, usually HDF5. The code loads event posterior samples, builds a KDE in the requested coordinates, and uses the chosen approximant group, defaulting to `C01:Mixed`.
 
 Important expectations:
 
@@ -194,7 +196,7 @@ Important expectations:
 
 ### COSMIC injection `.npz`
 
-`run_injections.py` writes an `.npz` file containing the COSMIC merger catalog used for selection calculations. Important arrays and metadata include:
+`gwbackpop-run-injections` writes an `.npz` file containing the COSMIC merger catalog used for selection calculations. Important arrays and metadata include:
 
 - `theta`: full sampled parameter vectors for merging COSMIC binaries.
 - `params`: parameter names matching the columns of `theta`.
@@ -320,7 +322,7 @@ gwbackpop-run-hierarchical \
 
 ### Single-event output
 
-`run_backpop.py` writes to `results/<event_name>/<config_name>/`:
+`gwbackpop-run-event` writes to `results/<event_name>/<config_name>/`:
 
 - `points.npy`: posterior samples in BackPop parameter space.
 - `log_w.npy`: log importance weights.
@@ -389,11 +391,11 @@ If that does not work, follow the COSMIC installation instructions for your syst
 Fast local checks that do not require COSMIC are:
 
 ```bash
-python smoke_test_imports.py --skip-cosmic
+gwbackpop-smoke-test --skip-cosmic
 pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py
 ```
 
-Injection catalogs written by `run_injections.py` keep their full scientific
+Injection catalogs written by `gwbackpop-run-injections` keep their full scientific
 arrays in the requested catalog NPZ and write metadata to a separate
 `*_metadata.npz`/JSON sidecar.  Two-dimensional catalogs record `z_form` as an
 auxiliary proposal draw: when explicit `log_q_proposal` weights are present,
@@ -405,7 +407,7 @@ active BackPop config.
 After installing COSMIC, run the full smoke import check with:
 
 ```bash
-python smoke_test_imports.py
+gwbackpop-smoke-test
 ```
 
 Heavy tests and production workflows that evolve COSMIC binaries or consume GW/LVK data products are intentionally kept separate from the GitHub Actions lightweight test job.

--- a/hierarchical_backpop_jax.py
+++ b/hierarchical_backpop_jax.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Legacy compatibility wrapper. Prefer the installed console command.
 """Compatibility wrapper. Prefer ``gwbackpop-run-hierarchical``."""
 from pathlib import Path
 import sys

--- a/plot_backpop.py
+++ b/plot_backpop.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Legacy compatibility wrapper. Prefer the installed console command.
 """Compatibility wrapper. Prefer ``gwbackpop-plot``."""
 from pathlib import Path
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "h5py",
   "matplotlib",
   "corner",
+  "seaborn",
   "arviz",
 ]
 
@@ -42,8 +43,6 @@ markers = [
   "cosmic: tests that import or run COSMIC binary-evolution code",
 ]
 
-[tool.setuptools]
-py-modules = ["run_backpop"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/run_GW150914.sh
+++ b/run_GW150914.sh
@@ -89,9 +89,9 @@ if [ ! -f "${SAMPLES}" ]; then
     exit 1
 fi
 
-for script in run_backpop.py plot_backpop.py; do
-    if [ ! -f "${script}" ]; then
-        echo "ERROR: ${script} not found in current directory."
+for cmd in gwbackpop-run-event gwbackpop-plot; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "ERROR: ${cmd} not found. Install the package with: python -m pip install -e '.[test]'"
         exit 1
     fi
 done
@@ -123,7 +123,7 @@ echo ""
 
 T1=$(date +%s)
 
-python run_backpop.py \
+gwbackpop-run-event \
     --samples_path             "${SAMPLES}" \
     --event_name               "${EVENT}" \
     --config_name              lucky_strikes \
@@ -151,7 +151,7 @@ echo ""
 
 T2=$(date +%s)
 
-python run_backpop.py \
+gwbackpop-run-event \
     --samples_path             "${SAMPLES}" \
     --event_name               "${EVENT}" \
     --config_name              lucky_strikes_zform \
@@ -178,7 +178,7 @@ echo ""
 echo "  Plotting 2D run (${DIR_2D})..."
 T3=$(date +%s)
 
-python plot_backpop.py \
+gwbackpop-plot \
     --results_dir  "${DIR_2D}" \
     --samples_path "${SAMPLES}" \
     --approximant  "${APPROXIMANT}" \
@@ -191,7 +191,7 @@ echo ""
 echo "  Plotting 3D run (${DIR_3D})..."
 T3b=$(date +%s)
 
-python plot_backpop.py \
+gwbackpop-plot \
     --results_dir  "${DIR_3D}" \
     --samples_path "${SAMPLES}" \
     --approximant  "${APPROXIMANT}" \
@@ -213,7 +213,7 @@ echo ""
 T4=$(date +%s)
 
 # Write comparison into the 2D directory so both share a common output
-python plot_backpop.py \
+gwbackpop-plot \
     --results_dir  "${DIR_2D}" \
     --compare_dir  "${DIR_3D}" \
     --samples_path "${SAMPLES}" \

--- a/run_backpop.py
+++ b/run_backpop.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Legacy compatibility wrapper. Prefer the installed console command.
 """Compatibility wrapper. Prefer ``gwbackpop-run-event``."""
 import sys
 from pathlib import Path

--- a/run_injections.py
+++ b/run_injections.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Legacy compatibility wrapper. Prefer the installed console command.
 """Compatibility wrapper. Prefer ``gwbackpop-run-injections``."""
 from pathlib import Path
 import sys

--- a/smoke_test_imports.py
+++ b/smoke_test_imports.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Legacy compatibility wrapper. Prefer the installed console command.
 """Compatibility wrapper. Prefer ``gwbackpop-smoke-test``."""
 from pathlib import Path
 import sys

--- a/tests/test_cli_invocation_hygiene.py
+++ b/tests/test_cli_invocation_hygiene.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+FORBIDDEN = [
+    "python run_backpop.py",
+    "python run_injections.py",
+    "python hierarchical_backpop_jax.py",
+    "python plot_backpop.py",
+    "python smoke_test_imports.py",
+]
+
+PATHS = [
+    Path("README.md"),
+    Path("run_GW150914.sh"),
+]
+
+
+def iter_workflow_files():
+    for pattern in [
+        "workflows/**/*.sh",
+        "workflows/**/*.slurm",
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+    ]:
+        yield from Path(".").glob(pattern)
+
+
+def test_user_facing_files_use_console_entry_points():
+    files = [p for p in PATHS if p.exists()] + [p for p in iter_workflow_files() if p.exists()]
+    violations = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for bad in FORBIDDEN:
+            if bad in text:
+                violations.append(f"{path}: contains forbidden legacy invocation {bad!r}")
+    assert not violations, "\n".join(violations)

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -1,0 +1,25 @@
+from importlib.metadata import entry_points
+from pathlib import Path
+import tomllib
+
+EXPECTED = {
+    "gwbackpop-run-event": "gwbackpop.cli.run_backpop:main",
+    "gwbackpop-run-injections": "gwbackpop.cli.run_injections:main",
+    "gwbackpop-run-hierarchical": "gwbackpop.cli.run_hierarchical:main",
+    "gwbackpop-plot": "gwbackpop.cli.plot_backpop:main",
+    "gwbackpop-smoke-test": "gwbackpop.cli.smoke_test:main",
+}
+
+
+def test_console_scripts_registered():
+    scripts = entry_points(group="console_scripts")
+    names = {ep.name: ep.value for ep in scripts}
+
+    missing = [name for name in EXPECTED if name not in names]
+    if missing:
+        # Source-tree fallback for non-installed local test runs; CI installs the
+        # package before running this test and exercises the actual metadata.
+        project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        names = project["project"]["scripts"]
+
+    assert {name: names[name] for name in EXPECTED} == EXPECTED

--- a/workflows/shell/run_hierarchical_2d.sh
+++ b/workflows/shell/run_hierarchical_2d.sh
@@ -8,12 +8,12 @@
 # injection campaign; production selection-corrected inference should use
 # run_hierarchical_3d.sh because selection effects are mass-redshift dependent.
 # Uses lucky_strikes posteriors (KDE over mc, q — flat logZ prior).
-# Sampler: NumPyro NUTS (HMC), implemented in hierarchical_backpop_jax.py.
+# Sampler: NumPyro NUTS (HMC), implemented in gwbackpop.inference.hierarchical.
 #
 # Prerequisites:
 #   1. SLURM catalog runs finished:  results/*/lucky_strikes/log_z.npy exist
 #   2. COSMIC merger catalog built:  injections/gwtc3_cosmic_mergers.npz exists
-#                                    (run_injections.py --config_name lucky_strikes without --pdet_path)
+#                                    (gwbackpop-run-injections --config_name lucky_strikes without --pdet_path)
 #   3. LVK found injection file:     $LVK_FOUND_PATH exists
 #
 # Selection effects: Farr (2019) estimator using raw LVK found injections.
@@ -79,6 +79,13 @@ OUTPUT_DIR="${RESULTS_ROOT}/hierarchical/${CONFIG_NAME}/nuts/lvk_farr"
 # ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
+
+for cmd in gwbackpop-run-hierarchical; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "ERROR: ${cmd} not found. Install the package with: python -m pip install -e '.[test]'"
+        exit 1
+    fi
+done
 
 echo "============================================================"
 echo " BackPop Hierarchical — 2D (NUTS/HMC)"

--- a/workflows/shell/run_hierarchical_3d.sh
+++ b/workflows/shell/run_hierarchical_3d.sh
@@ -6,12 +6,12 @@
 # RECOMMENDED PRODUCTION SCRIPT for selection-corrected hierarchical inference.
 # Uses lucky_strikes_zform posteriors (KDE over mc, q, z_merger +
 # Andrews+2021 cosmological priors on z_form and logZ).
-# Sampler: NumPyro NUTS (HMC), implemented in hierarchical_backpop_jax.py.
+# Sampler: NumPyro NUTS (HMC), implemented in gwbackpop.inference.hierarchical.
 #
 # Prerequisites:
-#   1. cosmo_prior.py fix deployed (z_merger_from_t_delay bug fixed).
+#   1. gwbackpop.cosmology fix deployed (z_merger_from_t_delay bug fixed).
 #   2. SLURM catalog re-runs finished: results/*/lucky_strikes_zform/log_z.npy
-#   3. COSMIC merger catalog re-run with fixed cosmo_prior.py:
+#   3. COSMIC merger catalog re-run with fixed gwbackpop.cosmology:
 #      injections/gwtc3_cosmic_mergers.npz  (old pre-fix NPZ is invalid)
 #   4. LVK found injection file available.
 #   5. Optional: run_hierarchical_2d.sh completed for a diagnostic comparison.
@@ -65,6 +65,13 @@ DIR_2D="${RESULTS_ROOT}/hierarchical/lucky_strikes/nuts/lvk_farr"
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 
+for cmd in gwbackpop-run-hierarchical; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "ERROR: ${cmd} not found. Install the package with: python -m pip install -e '.[test]'"
+        exit 1
+    fi
+done
+
 echo "============================================================"
 echo " BackPop Hierarchical — 3D (NUTS/HMC)"
 echo " Config:       ${CONFIG_NAME}"
@@ -76,7 +83,7 @@ echo " NUTS: ${NUM_CHAINS} chains x ${NUM_WARMUP} warmup + ${NUM_SAMPLES} sample
 echo " K matrix subsampled to N_found=${LVK_N_FOUND_MAX}"
 echo "============================================================"
 
-# Validate injection campaign was built with fixed cosmo_prior.py
+# Validate injection campaign was built with fixed gwbackpop.cosmology
 echo ""
 echo ">>> Checking injection campaign integrity..."
 python -c "
@@ -85,8 +92,8 @@ data  = np.load('${INJECTIONS_PATH}', allow_pickle=True)
 z_max = float(data['z_merger'].max())
 if z_max > 10:
     print(f'ERROR: z_merger max = {z_max:.1f} in injection NPZ.')
-    print('The pre-fix cosmo_prior.py was used — z_merger values are wrong.')
-    print('Delete the NPZ and re-run run_injections.py --config_name lucky_strikes with the fixed cosmo_prior.py.')
+    print('The pre-fix gwbackpop.cosmology was used — z_merger values are wrong.')
+    print('Delete the NPZ and re-run gwbackpop-run-injections --config_name lucky_strikes with the fixed gwbackpop.cosmology.')
     sys.exit(1)
 print(f'Injection NPZ valid: z_merger max = {z_max:.3f}')
 " || exit 1
@@ -239,7 +246,7 @@ echo " Outputs in: ${OUTPUT_DIR}/"
 echo ""
 echo " NOTE: NUTS does not compute log Z (marginal likelihood)."
 echo " For 2D vs 3D model comparison, either:"
-echo "   a) Re-run with hierarchical_backpop.py (Nautilus — gives log Z)"
+echo "   a) Re-run with gwbackpop-run-hierarchical using a Nautilus backend when available — gives log Z"
 echo "   b) Use ArviZ bridge sampling: arviz.waic() or loo() on both runs"
 echo ""
 

--- a/workflows/slurm/run_catalog_gwtc3.slurm
+++ b/workflows/slurm/run_catalog_gwtc3.slurm
@@ -20,10 +20,10 @@
 #   sbatch workflows/slurm/run_catalog_gwtc3.slurm
 #
 # Override PE samples directory:
-#   sbatch --export=ALL,PE_DIR=/path/to/samples run_catalog_gwtc3.slurm
+#   sbatch --export=ALL,PE_DIR=/path/to/samples workflows/slurm/run_catalog_gwtc3.slurm
 #
 # Run a specific subset (e.g. tasks 0–4):
-#   sbatch --array=0-4 run_catalog_gwtc3.slurm
+#   sbatch --array=0-4 workflows/slurm/run_catalog_gwtc3.slurm
 # =============================================================================
 
 #SBATCH --job-name=backpop_gwtc3
@@ -145,6 +145,14 @@ EVENT="${EVENTS[${SLURM_ARRAY_TASK_ID}]}"
 
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
+
+for cmd in gwbackpop-run-event gwbackpop-plot; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "ERROR: ${cmd} not found after activating ${CONDA_ENV}."
+        echo "Install with: python -m pip install -e '.[cosmic]' or activate the correct environment."
+        exit 1
+    fi
+done
 
 echo "============================================================"
 echo " Task:    ${SLURM_ARRAY_TASK_ID} / $((N_EVENTS-1))"


### PR DESCRIPTION
### Motivation

- Replace legacy root-level script invocations with the installed console entry points so user-facing docs and runnable workflows consistently recommend `gwbackpop-*` commands. 
- Ensure runnable shell and SLURM drivers verify command availability and guide users to install the package if the console commands are missing. 
- Prevent reintroduction of root-wrapper usage by adding automated hygiene checks and an entrypoint registration test. 

### Description

- Updated `README.md` to present the installed console commands (`gwbackpop-run-event`, `gwbackpop-run-injections`, `gwbackpop-run-hierarchical`, `gwbackpop-plot`, `gwbackpop-smoke-test`) as the canonical interface and added a short deprecation note for legacy wrappers. 
- Reworked `run_GW150914.sh` to perform `command -v` checks for `gwbackpop-run-event`/`gwbackpop-plot` and replaced all `python run_backpop.py` / `python plot_backpop.py` invocations with the corresponding `gwbackpop-*` commands while preserving all CLI flags. 
- Cleaned and modernized comments and user instructions in `workflows/shell/run_hierarchical_2d.sh` and `workflows/shell/run_hierarchical_3d.sh`, and added top-level availability checks for `gwbackpop-run-hierarchical`. 
- Updated `workflows/slurm/run_catalog_gwtc3.slurm` submit examples and added post-conda-activation `command -v` checks for `gwbackpop-run-event` and `gwbackpop-plot`. 
- Replaced CI invocation `python smoke_test_imports.py --skip-cosmic` with `gwbackpop-smoke-test --skip-cosmic` and added a CI step that runs the `--help` for all console entry points. 
- Added `tests/test_cli_invocation_hygiene.py` to fail when forbidden root-wrapper strings appear in user-facing files and `tests/test_console_entrypoints.py` to assert expected console scripts (with a source-tree fallback for local runs). 
- Kept root-wrapper files for compatibility but prefixed them with a single-line comment `# Legacy compatibility wrapper. Prefer the installed console command.` and removed top-level `py-modules` packaging from `pyproject.toml` so the package is discovered from `src/`. 
- Added `seaborn` to runtime dependencies because the plotting entry point imports plotting diagnostics that use it. 

### Testing

- `python -m pip install -e '.[test]'` — failed in this environment due to inability to fetch build/backend metadata (`setuptools.build_meta`) from the package index (network/403), so editable install could not be validated here. 
- `PYTHONPATH=src python -m gwbackpop.cli.smoke_test --skip-cosmic` — passed and reported dependency/module import status. 
- `PYTHONPATH=src pytest ... tests/test_cli_invocation_hygiene.py tests/test_console_entrypoints.py` — full lightweight test run passed: `29 passed, 7 warnings` (includes the two new tests). 
- Verified console-entrypoint help behavior by invoking entrypoint modules via `PYTHONPATH=src` and fixed a missing plotting dependency (`seaborn`) before retesting. 
- Performed static checks on the modified shell scripts with `bash -n` and verified there are no remaining forbidden legacy invocations in the scanned user-facing files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41dd95fb70832bb9735f1aab680b65)