### PR TITLE
Shared COSMIC selection accounting and diagnostic SNR-proxy pdet

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,35 @@ P_\mathrm{det}(m_{1,j},m_{2,j},z_j)
 
 where `q(\theta)` is the actual injection proposal density. The proposal density is not optional: changing how injections are drawn changes the denominator.
 
+
+### Diagnostic semi-analytic SNR proxy `pdet`
+
+For smoke tests, sanity checks, emulator seeding, and calibration diagnostics, `gwbackpop-run-injections` can populate `pdet` with a lightweight semi-analytic SNR proxy instead of a pickled interpolator:
+
+```bash
+gwbackpop-run-injections \
+  --config_name lucky_strikes \
+  --likelihood_mode 2D \
+  --pdet_mode snr_proxy \
+  --snr_pdet_method orientation_monte_carlo \
+  --snr_threshold 10.0 \
+  --output_path injections/gwtc3_snr_proxy_pdet.npz \
+  --n_inj 100000 \
+  --n_workers 16
+```
+
+The resulting catalog is consumed by the direct-`pdet` hierarchical mode without special cases:
+
+```bash
+gwbackpop-run-hierarchical \
+  --results_root results \
+  --config_name lucky_strikes \
+  --injections_path injections/gwtc3_snr_proxy_pdet.npz \
+  --output_dir results/hierarchical/lucky_strikes/nuts/direct_pdet_snr_proxy
+```
+
+**Warning:** the SNR proxy is diagnostic, not production selection. It uses a rough chirp-mass and luminosity-distance scaling plus a simple hard-threshold, logistic, or phenomenological orientation Monte Carlo mapping. It ignores search-pipeline ranking statistics, glitch rejection, detector duty cycle, waveform systematics, detailed PSD variation, and FAR thresholds. Compare SNR-proxy `alpha` values and posteriors against LVK/Farr or a calibrated `pdet` model before using them for science; for production, prefer LVK/Farr selection or a validated calibrated `pdet` model.
+
 ### 3. LVK/Farr found-injection estimator
 
 The production selection workflow uses COSMIC merger catalogs plus an LVK found-injection HDF5 file. The code builds a kernel matrix between LVK found injections and COSMIC mergers in `(\log m_1, \log m_2, z)` and uses a Farr-style estimator for `\alpha(\Lambda)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ all = ["pytest", "cosmic-popsynth"]
 gwbackpop-run-event = "gwbackpop.cli.run_backpop:main"
 gwbackpop-run-injections = "gwbackpop.cli.run_injections:main"
 gwbackpop-run-hierarchical = "gwbackpop.cli.run_hierarchical:main"
+gwbackpop-calibrate-snr-pdet = "gwbackpop.selection.calibrate_snr_pdet:main"
 gwbackpop-plot = "gwbackpop.cli.plot_backpop:main"
 gwbackpop-smoke-test = "gwbackpop.cli.smoke_test:main"
 

--- a/src/gwbackpop/inference/hierarchical.py
+++ b/src/gwbackpop/inference/hierarchical.py
@@ -1541,6 +1541,62 @@ def determine_selection_mode(injections_path: str | None, lvk_found_path: str | 
 
 
 
+def _compute_log_pop_static_for_catalog(cosmic_raw, injection_model_metadata: dict, log_q_arr: np.ndarray | None) -> np.ndarray | None:
+    """Population numerator factors not varied by hierarchical hyperparameters."""
+    if log_q_arr is None:
+        return None
+    from gwbackpop.cosmology import log_prior_z_form, log_prior_logZ_given_z_on_support
+
+    theta = cosmic_raw['theta'].astype(np.float64)
+    params = list(cosmic_raw['params'])
+    lo = cosmic_raw['lower_bound'].astype(np.float64)
+    hi = cosmic_raw['upper_bound'].astype(np.float64)
+    pidx = {p: i for i, p in enumerate(params)}
+    varied = {'alpha_1', 'alpha_2', 'flim_1', 'flim_2', 'vk1', 'vk2'}
+    sig = metadata_model_signature(injection_model_metadata)
+    uses_aux_z_form = _bool_meta(injection_model_metadata.get("uses_aux_z_form"), False)
+    log_pop_static = np.zeros(theta.shape[0], dtype=np.float64)
+
+    for name in params:
+        if name in varied:
+            continue
+        if name == "z_form" and (sig["uses_sfr_prior"] or uses_aux_z_form):
+            continue
+        if name == "logZ" and sig["uses_logZ_given_z_prior"]:
+            continue
+        idx = pidx[name]
+        width = hi[idx] - lo[idx]
+        if not width > 0.0:
+            raise ValueError(f"Invalid injection bounds for {name}: [{lo[idx]}, {hi[idx]}]")
+        log_pop_static += -np.log(width)
+
+    if (sig['uses_z_form'] or sig['uses_sfr_prior'] or sig['uses_logZ_given_z_prior'] or uses_aux_z_form):
+        if 'z_form' in cosmic_raw:
+            zf = cosmic_raw['z_form'].astype(np.float64)
+            if sig['uses_sfr_prior'] or uses_aux_z_form:
+                log_pop_static += np.array([log_prior_z_form(z) for z in zf], dtype=np.float64)
+            if sig['uses_logZ_given_z_prior']:
+                if 'logZ' not in cosmic_raw:
+                    raise ValueError("Injection metadata requires logZ prior but catalog lacks logZ")
+                lz = cosmic_raw['logZ'].astype(np.float64)
+                logz_idx = pidx.get("logZ")
+                default_support = injection_model_metadata.get("logZ_support", [-np.inf, np.inf])
+                logz_lo = float(lo[logz_idx]) if logz_idx is not None else float(default_support[0])
+                logz_hi = float(hi[logz_idx]) if logz_idx is not None else float(default_support[1])
+                log_pop_static += np.array([
+                    log_prior_logZ_given_z_on_support(zmet, z, logz_lo, logz_hi)
+                    for zmet, z in zip(lz, zf)
+                ], dtype=np.float64)
+        else:
+            warnings.warn(
+                "Injection file has log_q_proposal but lacks z_form; assuming cosmological proposal factors cancel.",
+                RuntimeWarning,
+            )
+    if not np.all(np.isfinite(log_pop_static)):
+        raise ValueError("Computed log_pop_static contains non-finite values")
+    return log_pop_static
+
+
 def load_cosmic_merger_catalog_for_selection(injections_path: str, event_model_metadata: list[dict], allow_inconsistent_selection_model: bool) -> tuple[dict, dict, bool, str]:
     """Load COSMIC merger injection NPZ and shared proposal/static-pop accounting."""
     cosmic_raw = np.load(injections_path, allow_pickle=True)
@@ -1555,8 +1611,19 @@ def load_cosmic_merger_catalog_for_selection(injections_path: str, event_model_m
     })
     selection_model_consistent, selection_model_consistency_message = validate_selection_model_consistency(event_model_metadata, injection_model_metadata, allow_inconsistent_selection_model)
     log_q_arr = cosmic_raw['log_q_proposal'].astype(np.float64) if 'log_q_proposal' in cosmic_raw else None
-    if log_q_arr is not None and not np.all(np.isfinite(log_q_arr)): raise ValueError("log_q_proposal contains non-finite values")
-    log_pop_static_arr = np.zeros(cosmic_raw['theta'].shape[0], dtype=np.float64) if log_q_arr is not None else None
+    if log_q_arr is not None:
+        if log_q_arr.shape[0] != cosmic_raw['theta'].shape[0]:
+            raise ValueError("log_q_proposal length must match theta")
+        if not np.all(np.isfinite(log_q_arr)):
+            raise ValueError("log_q_proposal contains non-finite values")
+        log_pop_static_arr = _compute_log_pop_static_for_catalog(cosmic_raw, injection_model_metadata, log_q_arr)
+        print("  Using explicit log_q_proposal from COSMIC merger catalog")
+    else:
+        warnings.warn(
+            "Injection file lacks log_q_proposal; falling back to legacy proposal reconstruction from bounds and kick_proposal_sigma.",
+            RuntimeWarning,
+        )
+        log_pop_static_arr = None
     cosmic = dict(theta=cosmic_raw['theta'].astype(np.float64), m1_src=cosmic_raw['m1_src'].astype(np.float64) if 'm1_src' in cosmic_raw else np.array([]), m2_src=cosmic_raw['m2_src'].astype(np.float64) if 'm2_src' in cosmic_raw else np.array([]), z_merger=cosmic_raw['z_merger'].astype(np.float64) if 'z_merger' in cosmic_raw else np.array([]), pdet=cosmic_raw['pdet'].astype(np.float64) if 'pdet' in cosmic_raw else None, params=list(cosmic_raw['params']), lo=cosmic_raw['lower_bound'].astype(np.float64), hi=cosmic_raw['upper_bound'].astype(np.float64), N_inj=int(cosmic_raw['N_inj'].ravel()[0]), N_merge=int(cosmic_raw['N_merge'].ravel()[0]), kick_sigma=float(cosmic_raw['kick_proposal_sigma'].ravel()[0] if 'kick_proposal_sigma' in cosmic_raw else 50.0), log_q_proposal=log_q_arr, log_pop_static=log_pop_static_arr)
     return cosmic, injection_model_metadata, selection_model_consistent, selection_model_consistency_message
 
@@ -1706,81 +1773,13 @@ def main():
             print(f"  Subsampled N_found: {N_found_total:,} -> {N_found_used:,}")
 
         print(f"\n Loading COSMIC merger catalog: {opts.injections_path}")
+        cosmic, injection_model_metadata, selection_model_consistent, selection_model_consistency_message = load_cosmic_merger_catalog_for_selection(
+            opts.injections_path,
+            event_model_metadata,
+            opts.allow_inconsistent_selection_model,
+        )
         cosmic_raw = np.load(opts.injections_path, allow_pickle=True)
-        if "metadata" in cosmic_raw:
-            injection_model_metadata = dict(cosmic_raw["metadata"].item())
-        else:
-            injection_model_metadata = {}
-        injection_model_metadata.update({
-            "likelihood_mode": _npz_scalar(cosmic_raw, "likelihood_mode", injection_model_metadata.get("likelihood_mode", "3D" if "z_form" in cosmic_raw else "2D")),
-            "uses_z_form": _npz_scalar(cosmic_raw, "uses_z_form", injection_model_metadata.get("uses_z_form", "z_form" in cosmic_raw)),
-            "uses_aux_z_form": _npz_scalar(cosmic_raw, "uses_aux_z_form", injection_model_metadata.get("uses_aux_z_form", False)),
-            "uses_sfr_prior": _npz_scalar(cosmic_raw, "uses_sfr_prior", injection_model_metadata.get("uses_sfr_prior", "z_form" in cosmic_raw)),
-            "uses_logZ_given_z_prior": _npz_scalar(cosmic_raw, "uses_logZ_given_z_prior", injection_model_metadata.get("uses_logZ_given_z_prior", "z_form" in cosmic_raw and "logZ" in cosmic_raw)),
-            "proposal_version": _npz_scalar(cosmic_raw, "proposal_version", injection_model_metadata.get("proposal_version", "unknown")),
-        })
-        selection_model_consistent, selection_model_consistency_message = validate_selection_model_consistency(
-            event_model_metadata, injection_model_metadata, opts.allow_inconsistent_selection_model
-        )
         print(f"  Selection model consistency: {selection_model_consistency_message}")
-        log_q_arr = None
-        log_pop_static_arr = None
-        if 'log_q_proposal' in cosmic_raw:
-            log_q_arr = cosmic_raw['log_q_proposal'].astype(np.float64)
-            if not np.all(np.isfinite(log_q_arr)):
-                raise ValueError("log_q_proposal contains non-finite values")
-            from gwbackpop.cosmology import log_prior_z_form, log_prior_logZ_given_z_on_support
-            theta_tmp = cosmic_raw['theta'].astype(np.float64)
-            params_tmp = list(cosmic_raw['params'])
-            lo_tmp = cosmic_raw['lower_bound'].astype(np.float64)
-            hi_tmp = cosmic_raw['upper_bound'].astype(np.float64)
-            pidx_tmp = {p: i for i, p in enumerate(params_tmp)}
-            log_pop_static_arr = np.zeros(theta_tmp.shape[0], dtype=np.float64)
-            inj_sig_for_weights = metadata_model_signature(injection_model_metadata)
-            for name in params_tmp:
-                if name == "z_form" and inj_sig_for_weights["uses_sfr_prior"]:
-                    continue
-                if name == "logZ" and inj_sig_for_weights["uses_logZ_given_z_prior"]:
-                    continue
-                if name not in ('alpha_1', 'alpha_2', 'flim_1', 'flim_2', 'vk1', 'vk2'):
-                    idx = pidx_tmp[name]
-                    log_pop_static_arr += -np.log(hi_tmp[idx] - lo_tmp[idx])
-            uses_aux_z_form = _bool_meta(injection_model_metadata.get("uses_aux_z_form"), False)
-            if (inj_sig_for_weights['uses_z_form'] or inj_sig_for_weights['uses_sfr_prior'] or inj_sig_for_weights['uses_logZ_given_z_prior'] or uses_aux_z_form) and 'z_form' in cosmic_raw and 'logZ' in cosmic_raw:
-                zf = cosmic_raw['z_form'].astype(np.float64)
-                lz = cosmic_raw['logZ'].astype(np.float64)
-                if inj_sig_for_weights['uses_sfr_prior'] or uses_aux_z_form:
-                    log_pop_static_arr += np.array([log_prior_z_form(z) for z in zf])
-                if inj_sig_for_weights['uses_logZ_given_z_prior']:
-                    logz_idx = pidx_tmp.get("logZ")
-                    logz_lo = float(lo_tmp[logz_idx]) if logz_idx is not None else float(injection_model_metadata.get("logZ_support", [-np.inf, np.inf])[0])
-                    logz_hi = float(hi_tmp[logz_idx]) if logz_idx is not None else float(injection_model_metadata.get("logZ_support", [-np.inf, np.inf])[1])
-                    log_pop_static_arr += np.array([log_prior_logZ_given_z_on_support(zmet, z, logz_lo, logz_hi) for zmet, z in zip(lz, zf)])
-            else:
-                warnings.warn(
-                    "Injection file has log_q_proposal but lacks z_form/logZ; "
-                    "assuming cosmological proposal factors cancel.",
-                    RuntimeWarning,
-                )
-            print("  Using explicit log_q_proposal from COSMIC merger catalog")
-
-        cosmic = dict(
-            theta    = cosmic_raw['theta'].astype(np.float64),
-            m1_src   = cosmic_raw['m1_src'].astype(np.float64),
-            m2_src   = cosmic_raw['m2_src'].astype(np.float64),
-            z_merger = cosmic_raw['z_merger'].astype(np.float64),
-            params   = list(cosmic_raw['params']),
-            lo       = cosmic_raw['lower_bound'].astype(np.float64),
-            hi       = cosmic_raw['upper_bound'].astype(np.float64),
-            N_inj    = int(cosmic_raw['N_inj'].ravel()[0]),
-            N_merge  = int(cosmic_raw['N_merge'].ravel()[0]),
-            kick_sigma = float(
-                cosmic_raw['kick_proposal_sigma'].ravel()[0]
-                if 'kick_proposal_sigma' in cosmic_raw else 50.0
-            ),
-            log_q_proposal = log_q_arr,
-            log_pop_static = log_pop_static_arr,
-        )
         print(f"  N_merge={cosmic['N_merge']:,}  N_COSMIC={cosmic['N_inj']:,}  "
               f"f_merge={cosmic['N_merge']/cosmic['N_inj']:.4f}")
 

--- a/src/gwbackpop/selection/calibrate_snr_pdet.py
+++ b/src/gwbackpop/selection/calibrate_snr_pdet.py
@@ -1,0 +1,49 @@
+"""Lightweight diagnostic comparison for semi-analytic SNR-proxy pdet."""
+from __future__ import annotations
+import argparse, csv, json
+import numpy as np
+import jax.numpy as jnp
+from scipy.special import logsumexp
+
+from gwbackpop.inference.hierarchical import POP_PARAM_NAMES, compute_log_wr_injections_numpy, load_cosmic_merger_catalog_for_selection
+from gwbackpop.selection.snr_pdet import make_snr_proxy_pdet_callable
+
+
+def _hyperpoint_to_vec(item):
+    if isinstance(item, dict):
+        return np.array([item[n] for n in POP_PARAM_NAMES], dtype=float)
+    arr = np.asarray(item, dtype=float)
+    if arr.size != len(POP_PARAM_NAMES):
+        raise ValueError(f"Hyperpoint lists must have {len(POP_PARAM_NAMES)} entries")
+    return arr
+
+
+def log_alpha_snr_proxy(cosmic, lp_vec, pdet_callable):
+    pdet = pdet_callable(cosmic["m1_src"], cosmic["m2_src"], cosmic["z_merger"])
+    log_wr = compute_log_wr_injections_numpy(lp_vec, cosmic["theta"], cosmic["params"], cosmic["lo"], cosmic["hi"], cosmic["kick_sigma"], cosmic.get("log_q_proposal"), cosmic.get("log_pop_static"))
+    return float(logsumexp(np.where(pdet > 0.0, np.log(pdet), -np.inf) + log_wr) - np.log(cosmic["N_inj"]))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Diagnostic SNR-proxy pdet alpha comparison/threshold scan.")
+    ap.add_argument("--injections_path", required=True)
+    ap.add_argument("--hyperpoints_json", required=True)
+    ap.add_argument("--output_csv", required=True)
+    ap.add_argument("--method", default="orientation_monte_carlo", choices=["hard_threshold", "orientation_monte_carlo", "logistic"])
+    ap.add_argument("--rho_threshold", type=float, default=10.0)
+    ap.add_argument("--sensitivity_scale", type=float, default=1.0)
+    ap.add_argument("--threshold_scan", default=None, help="Optional comma-separated thresholds; writes rows for each.")
+    args = ap.parse_args(argv)
+    cosmic, *_ = load_cosmic_merger_catalog_for_selection(args.injections_path, [], True)
+    hyperpoints = [_hyperpoint_to_vec(x) for x in json.load(open(args.hyperpoints_json))]
+    thresholds = [float(x) for x in args.threshold_scan.split(",")] if args.threshold_scan else [args.rho_threshold]
+    with open(args.output_csv, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["hyperpoint", "log_alpha_snr_proxy", "log_alpha_lvk_farr", "delta_log_alpha", "rho_threshold", "sensitivity_scale", "method"])
+        writer.writeheader()
+        for th in thresholds:
+            pdet = make_snr_proxy_pdet_callable(method=args.method, rho_threshold=th, sensitivity_scale=args.sensitivity_scale)
+            for i, hp in enumerate(hyperpoints):
+                writer.writerow(dict(hyperpoint=i, log_alpha_snr_proxy=log_alpha_snr_proxy(cosmic, hp, pdet), log_alpha_lvk_farr=np.nan, delta_log_alpha=np.nan, rho_threshold=th, sensitivity_scale=args.sensitivity_scale, method=args.method))
+
+if __name__ == "__main__":
+    main()

--- a/src/gwbackpop/selection/injections.py
+++ b/src/gwbackpop/selection/injections.py
@@ -118,7 +118,7 @@ ZFORM_MAX = 20.0
 # Worker function (runs in subprocess — must be importable at module level)
 # ---------------------------------------------------------------------------
 
-def _worker_init(pdet_path: str | None, config_name: str = DEFAULT_CONFIG_NAME, likelihood_mode: str = "2D") -> None:
+def _worker_init(pdet_path: str | None, config_name: str = DEFAULT_CONFIG_NAME, likelihood_mode: str = "2D", pdet_callable=None) -> None:
     """Load P_det interpolator once per worker process.
     If pdet_path is None, P_det evaluation is skipped and pdet=nan is stored.
     Use this mode when building the COSMIC merger catalog for LVKInjectionCampaign.
@@ -126,6 +126,9 @@ def _worker_init(pdet_path: str | None, config_name: str = DEFAULT_CONFIG_NAME, 
     global _PDET, LOWER, UPPER, PARAMS, FIXED_PARAMS, LIKELIHOOD_MODE
     LOWER, UPPER, PARAMS, FIXED_PARAMS = _load_config(config_name)
     LIKELIHOOD_MODE = str(likelihood_mode).upper()
+    if pdet_callable is not None:
+        _PDET = pdet_callable
+        return
     if pdet_path is None:
         _PDET = None
         return
@@ -434,6 +437,56 @@ def _draw_logZ_given_z(rng: np.random.Generator, z_form: float,
 # Campaign runner
 # ---------------------------------------------------------------------------
 
+def resolve_pdet_callable(
+    pdet_mode: str = "auto",
+    pdet_path: str | None = None,
+    *,
+    snr_pdet_method: str = "orientation_monte_carlo",
+    snr_threshold: float = 10.0,
+    snr_ref: float = 20.0,
+    snr_mc_ref: float = 26.1,
+    snr_d_ref_mpc: float = 1000.0,
+    snr_sensitivity_scale: float = 1.0,
+    snr_logistic_width: float = 1.0,
+    snr_orientation_seed: int = 1234,
+    snr_n_orientation: int = 200000,
+):
+    """Resolve injection pdet mode into a callable/path plus metadata."""
+    mode = str(pdet_mode).lower()
+    if mode == "auto":
+        mode = "pickle" if pdet_path else "none"
+    if mode not in {"none", "pickle", "snr_proxy"}:
+        raise ValueError("pdet_mode must be one of auto, none, pickle, snr_proxy")
+    metadata = {"pdet_mode": mode}
+    if mode == "none":
+        return None, None, metadata
+    if mode == "pickle":
+        if not pdet_path:
+            raise ValueError("pdet_mode='pickle' requires --pdet_path")
+        return pdet_path, None, metadata
+    if pdet_path:
+        warnings.warn("pdet_mode='snr_proxy' ignores --pdet_path", RuntimeWarning)
+    from gwbackpop.selection.snr_pdet import make_snr_proxy_pdet_callable
+    callable_ = make_snr_proxy_pdet_callable(
+        method=snr_pdet_method, rho_threshold=snr_threshold, rho_ref=snr_ref,
+        mc_ref=snr_mc_ref, d_ref_mpc=snr_d_ref_mpc,
+        sensitivity_scale=snr_sensitivity_scale, logistic_width=snr_logistic_width,
+        seed=snr_orientation_seed, n_orientation=snr_n_orientation,
+    )
+    metadata.update(
+        pdet_model_name="semi_analytic_snr_proxy",
+        snr_pdet_method=snr_pdet_method, snr_threshold=float(snr_threshold),
+        snr_ref=float(snr_ref), snr_mc_ref=float(snr_mc_ref),
+        snr_d_ref_mpc=float(snr_d_ref_mpc),
+        snr_sensitivity_scale=float(snr_sensitivity_scale),
+        snr_logistic_width=float(snr_logistic_width),
+        snr_orientation_seed=int(snr_orientation_seed),
+        snr_n_orientation=int(snr_n_orientation),
+        pdet_is_diagnostic=True, pdet_production_ready=False,
+    )
+    return None, callable_, metadata
+
+
 def run_campaign(
     pdet_path: str | None,
     output_path: str,
@@ -442,6 +495,16 @@ def run_campaign(
     chunk_size: int = 500,
     config_name: str | None = None,
     likelihood_mode: str = "2D",
+    pdet_mode: str = "auto",
+    snr_pdet_method: str = "orientation_monte_carlo",
+    snr_threshold: float = 10.0,
+    snr_ref: float = 20.0,
+    snr_mc_ref: float = 26.1,
+    snr_d_ref_mpc: float = 1000.0,
+    snr_sensitivity_scale: float = 1.0,
+    snr_logistic_width: float = 1.0,
+    snr_orientation_seed: int = 1234,
+    snr_n_orientation: int = 200000,
 ) -> None:
     """Run the full injection campaign and save results.
 
@@ -466,6 +529,13 @@ def run_campaign(
         raise ValueError("likelihood_mode must be 2D or 3D")
 
     os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    pdet_path_resolved, pdet_callable, pdet_metadata = resolve_pdet_callable(
+        pdet_mode, pdet_path, snr_pdet_method=snr_pdet_method,
+        snr_threshold=snr_threshold, snr_ref=snr_ref, snr_mc_ref=snr_mc_ref,
+        snr_d_ref_mpc=snr_d_ref_mpc, snr_sensitivity_scale=snr_sensitivity_scale,
+        snr_logistic_width=snr_logistic_width, snr_orientation_seed=snr_orientation_seed,
+        snr_n_orientation=snr_n_orientation,
+    )
     start = time.time()
 
     # Seeds: deterministic, reproducible, one per injection
@@ -480,14 +550,15 @@ def run_campaign(
         "truncated Maxwellian kick speeds and isotropic COSMIC kick directions; "
         "do not combine its log_q_proposal with older proposal versions."
     )
-    print(f"[injections] pdet: {pdet_path}")
+    print(f"[injections] pdet_mode: {pdet_metadata['pdet_mode']}")
+    print(f"[injections] pdet: {pdet_path_resolved}")
     print(f"[injections] output: {output_path}")
     print()
 
     with Pool(
         processes=n_workers,
         initializer=_worker_init,
-        initargs=(pdet_path, config_name, LIKELIHOOD_MODE),
+        initargs=(pdet_path_resolved, config_name, LIKELIHOOD_MODE, pdet_callable),
     ) as pool:
         for i in range(0, n_inj, chunk_size):
             batch = seeds[i : i + chunk_size]
@@ -572,7 +643,8 @@ def run_campaign(
         uses_logZ_given_z_prior=bool(LIKELIHOOD_MODE == "3D"),
         logZ_support=[float(LOGZ_LO), float(LOGZ_HI)],
         coordinate_system=COORDINATE_SYSTEM,
-        pdet_path=pdet_path,
+        pdet_path=pdet_path_resolved,
+        **pdet_metadata,
         n_workers=int(n_workers),
         chunk_size=int(chunk_size),
         wall_time_s=float(elapsed),
@@ -610,6 +682,19 @@ def run_campaign(
         uses_sfr_prior        = np.array([LIKELIHOOD_MODE == "3D"]),
         uses_logZ_given_z_prior = np.array([LIKELIHOOD_MODE == "3D"]),
         wall_time_s          = np.array([elapsed]),
+        pdet_mode           = np.array([pdet_metadata["pdet_mode"]]),
+        pdet_model_name      = np.array([pdet_metadata.get("pdet_model_name", "")]),
+        snr_pdet_method      = np.array([pdet_metadata.get("snr_pdet_method", "")]),
+        snr_threshold        = np.array([pdet_metadata.get("snr_threshold", np.nan)]),
+        snr_ref              = np.array([pdet_metadata.get("snr_ref", np.nan)]),
+        snr_mc_ref           = np.array([pdet_metadata.get("snr_mc_ref", np.nan)]),
+        snr_d_ref_mpc        = np.array([pdet_metadata.get("snr_d_ref_mpc", np.nan)]),
+        snr_sensitivity_scale = np.array([pdet_metadata.get("snr_sensitivity_scale", np.nan)]),
+        snr_logistic_width   = np.array([pdet_metadata.get("snr_logistic_width", np.nan)]),
+        snr_orientation_seed = np.array([pdet_metadata.get("snr_orientation_seed", -1)]),
+        snr_n_orientation    = np.array([pdet_metadata.get("snr_n_orientation", -1)]),
+        pdet_is_diagnostic   = np.array([pdet_metadata.get("pdet_is_diagnostic", False)]),
+        pdet_production_ready = np.array([pdet_metadata.get("pdet_production_ready", pdet_metadata["pdet_mode"] == "pickle")]),
         metadata             = np.array(metadata, dtype=object),
     )
     catalog_path = os.fspath(output_path)
@@ -626,10 +711,18 @@ def run_campaign(
 def parse_args():
     p = ArgumentParser(description="BackPop injection campaign for selection effects.")
     p.add_argument("--pdet_path",   default=None,
-                   help="Path to pickled P_det(m1_src, m2_src, z) interpolator. "
-                        "If omitted, pdet values are not computed and stored as nan. "
-                        "Use this when building the COSMIC merger catalog for "
-                        "LVKInjectionCampaign (raw found-injection Farr estimator).")
+                   help="Path to pickled P_det(m1_src, m2_src, z) interpolator.")
+    p.add_argument("--pdet_mode", choices=["auto", "none", "pickle", "snr_proxy"], default="auto",
+                   help="P_det source: auto uses pickle when --pdet_path is set, else none; snr_proxy is diagnostic only.")
+    p.add_argument("--snr_pdet_method", choices=["hard_threshold", "orientation_monte_carlo", "logistic"], default="orientation_monte_carlo")
+    p.add_argument("--snr_threshold", type=float, default=10.0)
+    p.add_argument("--snr_ref", type=float, default=20.0)
+    p.add_argument("--snr_mc_ref", type=float, default=26.1)
+    p.add_argument("--snr_d_ref_mpc", type=float, default=1000.0)
+    p.add_argument("--snr_sensitivity_scale", type=float, default=1.0)
+    p.add_argument("--snr_logistic_width", type=float, default=1.0)
+    p.add_argument("--snr_orientation_seed", type=int, default=1234)
+    p.add_argument("--snr_n_orientation", type=int, default=200000)
     p.add_argument("--output_path", required=True,
                    help="Output NPZ file path.")
     p.add_argument("--n_inj",       type=int, default=1_000_000,
@@ -664,6 +757,16 @@ def main():
         chunk_size  = opts.chunk_size,
         config_name  = opts.config_name,
         likelihood_mode = opts.likelihood_mode,
+        pdet_mode = opts.pdet_mode,
+        snr_pdet_method = opts.snr_pdet_method,
+        snr_threshold = opts.snr_threshold,
+        snr_ref = opts.snr_ref,
+        snr_mc_ref = opts.snr_mc_ref,
+        snr_d_ref_mpc = opts.snr_d_ref_mpc,
+        snr_sensitivity_scale = opts.snr_sensitivity_scale,
+        snr_logistic_width = opts.snr_logistic_width,
+        snr_orientation_seed = opts.snr_orientation_seed,
+        snr_n_orientation = opts.snr_n_orientation,
     )
 
 

--- a/src/gwbackpop/selection/snr_pdet.py
+++ b/src/gwbackpop/selection/snr_pdet.py
@@ -1,0 +1,98 @@
+"""Diagnostic semi-analytic SNR-proxy detection probability.
+
+This module is intentionally lightweight and approximate.  It is useful for
+smoke tests, emulator seeding, and calibration diagnostics, but it is not a
+production substitute for LVK/Farr selection or a validated pdet model.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+from scipy.special import expit
+
+try:
+    from astropy.cosmology import Planck15 as _COSMO
+except Exception:  # pragma: no cover
+    _COSMO = None
+
+
+_VALID_METHODS = {"hard_threshold", "orientation_monte_carlo", "logistic"}
+
+
+def chirp_mass_detector(m1_src, m2_src, z):
+    m1 = np.asarray(m1_src, dtype=np.float64) * (1.0 + np.asarray(z, dtype=np.float64))
+    m2 = np.asarray(m2_src, dtype=np.float64) * (1.0 + np.asarray(z, dtype=np.float64))
+    return (m1 * m2) ** (3.0 / 5.0) / (m1 + m2) ** (1.0 / 5.0)
+
+
+def luminosity_distance_mpc(z):
+    z = np.asarray(z, dtype=np.float64)
+    if _COSMO is not None:
+        return np.asarray(_COSMO.luminosity_distance(z).to_value("Mpc"), dtype=np.float64)
+    # Low-z fallback; keeps tests usable if astropy is unavailable.
+    c_over_h0 = 299792.458 / 67.74
+    return c_over_h0 * z * (1.0 + 0.5 * z)
+
+
+def snr_proxy_rho_opt(m1_src, m2_src, z, *, rho_ref=20.0, mc_ref=26.1, d_ref_mpc=1000.0, sensitivity_scale=1.0, high_mass_rolloff=True):
+    mc = chirp_mass_detector(m1_src, m2_src, z)
+    dl = np.maximum(luminosity_distance_mpc(z), 1e-9)
+    rho = float(rho_ref) * (mc / float(mc_ref)) ** (5.0 / 6.0) * (float(d_ref_mpc) / dl) * float(sensitivity_scale)
+    if high_mass_rolloff:
+        mtot_det = (np.asarray(m1_src, dtype=np.float64) + np.asarray(m2_src, dtype=np.float64)) * (1.0 + np.asarray(z, dtype=np.float64))
+        rho = rho / np.sqrt(1.0 + (mtot_det / 180.0) ** 4)
+    return np.where(np.isfinite(rho), rho, 0.0)
+
+
+@dataclass(frozen=True)
+class SNRProxyPdet:
+    method: str = "orientation_monte_carlo"
+    rho_threshold: float = 10.0
+    rho_ref: float = 20.0
+    mc_ref: float = 26.1
+    d_ref_mpc: float = 1000.0
+    sensitivity_scale: float = 1.0
+    logistic_width: float = 1.0
+    seed: int = 1234
+    n_orientation: int = 200000
+
+    def __post_init__(self):
+        if self.method not in _VALID_METHODS:
+            raise ValueError(f"Unknown SNR pdet method {self.method!r}; choose {sorted(_VALID_METHODS)}")
+        if self.rho_threshold <= 0 or self.rho_ref <= 0 or self.mc_ref <= 0 or self.d_ref_mpc <= 0 or self.sensitivity_scale < 0:
+            raise ValueError("SNR proxy scales must be positive, with non-negative sensitivity_scale")
+        if self.logistic_width <= 0:
+            raise ValueError("logistic_width must be positive")
+        if self.n_orientation <= 0:
+            raise ValueError("n_orientation must be positive")
+        rng = np.random.default_rng(self.seed)
+        # Phenomenological bounded projection: antenna power and inclination.
+        cosi = rng.uniform(-1.0, 1.0, self.n_orientation)
+        inc = 0.5 * np.sqrt((1.0 + cosi**2) ** 2 + (2.0 * cosi) ** 2) / np.sqrt(2.0)
+        antenna = rng.beta(2.0, 4.0, self.n_orientation) ** 0.5
+        w = np.clip(inc * antenna, 0.0, 1.0)
+        object.__setattr__(self, "_w_sorted", np.sort(w))
+
+    def rho_opt(self, m1_src, m2_src, z):
+        return snr_proxy_rho_opt(m1_src, m2_src, z, rho_ref=self.rho_ref, mc_ref=self.mc_ref, d_ref_mpc=self.d_ref_mpc, sensitivity_scale=self.sensitivity_scale)
+
+    def pdet_from_rho(self, rho_opt):
+        rho = np.asarray(rho_opt, dtype=np.float64)
+        if self.method == "hard_threshold":
+            out = (rho > self.rho_threshold).astype(np.float64)
+        elif self.method == "logistic":
+            out = expit((rho - self.rho_threshold) / self.logistic_width)
+            out = np.where(rho > 0.0, out, 0.0)
+        else:
+            need = np.divide(self.rho_threshold, rho, out=np.full_like(rho, np.inf), where=rho > 0.0)
+            idx = np.searchsorted(self._w_sorted, need, side="right")
+            out = (self._w_sorted.size - idx) / self._w_sorted.size
+        return np.clip(np.where(rho > 0.0, out, 0.0), 0.0, 1.0)
+
+    def __call__(self, m1_src, m2_src, z):
+        out = self.pdet_from_rho(self.rho_opt(m1_src, m2_src, z))
+        return float(out) if np.ndim(out) == 0 else out
+
+
+def make_snr_proxy_pdet_callable(method='orientation_monte_carlo', rho_threshold=10.0, rho_ref=20.0, mc_ref=26.1, d_ref_mpc=1000.0, sensitivity_scale=1.0, logistic_width=1.0, seed=1234, n_orientation=200000):
+    return SNRProxyPdet(method=method, rho_threshold=rho_threshold, rho_ref=rho_ref, mc_ref=mc_ref, d_ref_mpc=d_ref_mpc, sensitivity_scale=sensitivity_scale, logistic_width=logistic_width, seed=seed, n_orientation=n_orientation)

--- a/tests/test_selection_catalog_helper.py
+++ b/tests/test_selection_catalog_helper.py
@@ -1,0 +1,59 @@
+import inspect
+import numpy as np
+import jax.numpy as jnp
+import pytest
+from scipy.special import logsumexp
+
+from gwbackpop.inference import hierarchical as h
+
+
+def _write_toy(path):
+    params = np.array(["alpha_1", "alpha_2", "flim_1", "flim_2", "vk1", "vk2", "logtb"], dtype="U16")
+    theta = np.array([
+        [1.0, 1.2, 0.3, 0.4, 30.0, 40.0, 2.0],
+        [1.5, 1.1, 0.5, 0.6, 50.0, 60.0, 3.0],
+        [2.0, 1.4, 0.7, 0.5, 70.0, 80.0, 4.0],
+    ])
+    lo = np.array([0.1, 0.1, 0.0, 0.0, 0.0, 0.0, 1.0])
+    hi = np.array([10.0, 10.0, 1.0, 1.0, 500.0, 500.0, 5.0])
+    np.savez(path, theta=theta, params=params, lower_bound=lo, upper_bound=hi,
+             log_q_proposal=np.array([-8.0, -8.1, -8.2]), pdet=np.array([0.2, 0.3, 0.4]),
+             m1_src=np.array([30, 31, 32.]), m2_src=np.array([20, 21, 22.]), z_merger=np.array([.1,.2,.3]),
+             N_inj=np.array([10]), N_merge=np.array([3]), kick_proposal_sigma=np.array([50.0]),
+             likelihood_mode=np.array(["2D"]), uses_aux_z_form=np.array([False]),
+             uses_sfr_prior=np.array([False]), uses_logZ_given_z_prior=np.array([False]),
+             metadata=np.array({"likelihood_mode":"2D", "uses_aux_z_form": False, "uses_sfr_prior": False, "uses_logZ_given_z_prior": False}, dtype=object))
+
+
+def test_shared_catalog_helper_static_terms(tmp_path):
+    f = tmp_path / "toy.npz"; _write_toy(f)
+    cosmic, meta, ok, msg = h.load_cosmic_merger_catalog_for_selection(str(f), [], True)
+    for key in ["theta", "m1_src", "m2_src", "z_merger", "pdet", "params", "lo", "hi", "N_inj", "N_merge", "kick_sigma", "log_q_proposal", "log_pop_static"]:
+        assert key in cosmic
+    assert ok
+    assert np.allclose(cosmic["pdet"], [0.2, 0.3, 0.4])
+    assert np.all(np.isfinite(cosmic["log_q_proposal"]))
+    assert np.all(np.isfinite(cosmic["log_pop_static"]))
+    assert not np.allclose(cosmic["log_pop_static"], 0.0)
+    assert np.allclose(cosmic["log_pop_static"], -np.log(4.0))
+
+
+def test_direct_alpha_static_terms_change_alpha():
+    theta = np.array([[1.0], [2.0], [3.0]])
+    lo = np.array([0.1]); hi = np.array([10.0]); params = {"alpha_1": 0}
+    pdet = np.array([0.2, 0.4, 0.8]); log_q = np.array([-1.0, -1.0, -1.0])
+    static = np.array([0.0, 0.5, 1.0]); lp = h.default_hyperparams()
+    fn = h.make_log_alpha_direct_pdet_fn(jnp.array(theta), jnp.array(pdet), jnp.array(lo), jnp.array(hi), params, 20, 50.0, jnp.array(log_q), jnp.array(static))
+    got = float(fn(lp))
+    log_wr = h.compute_log_wr_injections_numpy(lp, theta, ["alpha_1"], lo, hi, 50.0, log_q, static)
+    expected = logsumexp(np.log(pdet) + log_wr) - np.log(20)
+    assert got == pytest.approx(expected)
+    no_static = h.make_log_alpha_direct_pdet_fn(jnp.array(theta), jnp.array(pdet), jnp.array(lo), jnp.array(hi), params, 20, 50.0, jnp.array(log_q), jnp.zeros(3))
+    assert float(no_static(lp)) != pytest.approx(got)
+
+
+def test_lvk_farr_reuses_shared_catalog_helper():
+    src = inspect.getsource(h.main)
+    lvk_part = src.split('elif selection_mode == "lvk_farr"', 1)[1]
+    assert "load_cosmic_merger_catalog_for_selection" in lvk_part
+    assert "log_pop_static_arr = np.zeros" not in lvk_part

--- a/tests/test_snr_pdet_proxy.py
+++ b/tests/test_snr_pdet_proxy.py
@@ -1,0 +1,44 @@
+import pickle
+import numpy as np
+import pytest
+
+from gwbackpop.selection.snr_pdet import make_snr_proxy_pdet_callable
+from gwbackpop.selection.injections import resolve_pdet_callable
+
+
+def test_snr_proxy_monotonicity_and_bounds():
+    pdet = make_snr_proxy_pdet_callable(n_orientation=5000, seed=1)
+    vals = pdet(30.0, 30.0, np.array([0.05, 0.2, 0.6]))
+    assert np.all(np.isfinite(vals))
+    assert np.all((0.0 <= vals) & (vals <= 1.0))
+    assert np.all(np.diff(vals) <= 0.0)
+    lo = make_snr_proxy_pdet_callable(sensitivity_scale=0.5, n_orientation=5000, seed=1)(30.0, 30.0, 0.2)
+    hi = make_snr_proxy_pdet_callable(sensitivity_scale=2.0, n_orientation=5000, seed=1)(30.0, 30.0, 0.2)
+    assert hi >= lo
+
+
+def test_snr_proxy_hard_threshold():
+    p = make_snr_proxy_pdet_callable(method="hard_threshold", rho_threshold=10.0, rho_ref=20.0, d_ref_mpc=1000.0, sensitivity_scale=1.0)
+    assert p.pdet_from_rho(np.array([11.0]))[0] == 1.0
+    assert p.pdet_from_rho(np.array([9.0]))[0] == 0.0
+
+
+@pytest.mark.parametrize("method", ["orientation_monte_carlo", "logistic"])
+def test_snr_proxy_soft_methods_increase_with_rho(method):
+    p = make_snr_proxy_pdet_callable(method=method, n_orientation=5000, seed=2)
+    vals = p.pdet_from_rho(np.array([1.0, 10.0, 30.0]))
+    assert np.all((0.0 <= vals) & (vals <= 1.0))
+    assert np.all(np.diff(vals) >= 0.0)
+
+
+def test_injection_pdet_mode_parsing(tmp_path):
+    path, callable_, meta = resolve_pdet_callable("none", None)
+    assert path is None and callable_ is None and meta["pdet_mode"] == "none"
+    path, callable_, meta = resolve_pdet_callable("snr_proxy", None, snr_n_orientation=1000)
+    assert path is None and callable_ is not None and meta["pdet_model_name"] == "semi_analytic_snr_proxy"
+    with pytest.raises(ValueError, match="requires"):
+        resolve_pdet_callable("pickle", None)
+    pkl = tmp_path / "p.pkl"
+    pkl.write_bytes(pickle.dumps(abs))
+    path, callable_, meta = resolve_pdet_callable("pickle", str(pkl))
+    assert path == str(pkl) and callable_ is None and meta["pdet_mode"] == "pickle"


### PR DESCRIPTION
### Motivation
- Unify duplicated COSMIC injection/proposal accounting so both `direct_pdet` and `lvk_farr` use a single validated helper that constructs `log_q_proposal` and `log_pop_static` consistently. 
- Provide a fast, clearly diagnostic semi-analytic `pdet` proxy for injection-catalog generation and calibration diagnostics without requiring a pickled interpolator.

### Description
- Centralized COSMIC injection loading and proposal/static-pop accounting in `load_cosmic_merger_catalog_for_selection()` and added `_compute_log_pop_static_for_catalog()` to compute non-varied numerator factors, returning `cosmic, injection_model_metadata, selection_model_consistent, selection_model_consistency_message`. 
- Rewrote the `lvk_farr` branch to call the shared helper and removed the duplicated inline reconstruction, ensuring `log_q_proposal`/`log_pop_static` are identical between modes and passed into `make_log_alpha_fn`/`make_log_alpha_direct_pdet_fn`. 
- Added a diagnostic semi-analytic SNR-proxy in `src/gwbackpop/selection/snr_pdet.py` implementing detector-frame chirp-mass scaling, luminosity-distance conversion (uses `astropy` if available), and `pdet` mappings: `hard_threshold`, `orientation_monte_carlo`, and `logistic`, plus `make_snr_proxy_pdet_callable()` factory. 
- Wired a new `--pdet_mode {auto,none,pickle,snr_proxy}` and related `--snr_*` CLI options into `gwbackpop-run-injections`, enabled worker init with an internal `pdet` callable, stored diagnostic `pdet` metadata in the output NPZ, and added a small diagnostic CLI `src/gwbackpop/selection/calibrate_snr_pdet.py` for alpha comparisons/threshold scans. 
- Added tests exercising the shared catalog helper and static-term accounting and the SNR proxy behavior, and documented the diagnostic SNR-proxy workflow and warnings in the README.

### Testing
- Ran unit tests with `PYTHONPATH=src pytest tests/test_snr_pdet_proxy.py tests/test_selection_catalog_helper.py tests/test_direct_pdet_selection.py` and broader test set `PYTHONPATH=src pytest ...` (full CI subset); the test suite completed successfully (`45 passed`, several warnings). 
- Exercised CLI/help entrypoints via `PYTHONPATH=src python -m gwbackpop.selection.injections --help`, `PYTHONPATH=src python -m gwbackpop.inference.hierarchical --help`, and smoke-test module `PYTHONPATH=src python -m gwbackpop.cli.smoke_test --skip-cosmic`, all of which ran without error. 
- Attempted `python -m pip install -e '.[test]'` in this environment but the install failed due to external package index access (`setuptools` resolution returned 403), which is an environment constraint and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4226596a60832b854985d8f743601a)