### PR TITLE
Selection follow-ups: CI tests, catalog loader hardening, and calibrate_snr_pdet docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,8 @@ jobs:
           gwbackpop-run-event --help
           gwbackpop-run-injections --help
           gwbackpop-run-hierarchical --help
+          gwbackpop-calibrate-snr-pdet --help
           gwbackpop-plot --help
           gwbackpop-smoke-test --help
       - name: Run lightweight tests
-        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py tests/test_injection_proposal.py tests/test_cli_invocation_hygiene.py tests/test_console_entrypoints.py
+        run: pytest tests/test_lightweight_infrastructure.py tests/test_truncated_population_densities.py tests/test_hierarchical_toy_recovery.py tests/test_selection_model_consistency.py tests/test_default_hyperparams.py tests/test_injection_proposal.py tests/test_cli_invocation_hygiene.py tests/test_console_entrypoints.py tests/test_direct_pdet_selection.py tests/test_selection_catalog_helper.py tests/test_snr_pdet_proxy.py

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Additional utilities:
 
 - `gwbackpop-run-injections` builds COSMIC merger catalogs for selection corrections. It can either store a direct `P_det(m_1, m_2, z)` value from a pickled interpolator or store `pdet=nan` for the LVK/Farr workflow.
 - `gwbackpop-plot` makes diagnostic figures from single-event output directories.
+- `gwbackpop-calibrate-snr-pdet` runs threshold-scan diagnostics for the semi-analytic SNR-proxy detection probability. It currently writes LVK/Farr comparison columns as `NaN`; those columns should be interpreted as placeholders until Farr calibration is implemented in this utility.
 - `workflows/shell/run_hierarchical_2d.sh`, `workflows/shell/run_hierarchical_3d.sh`, and `workflows/slurm/run_catalog_gwtc3.slurm` are convenience wrappers for catalog-scale analyses.
 
 

--- a/src/gwbackpop/inference/hierarchical.py
+++ b/src/gwbackpop/inference/hierarchical.py
@@ -1597,9 +1597,36 @@ def _compute_log_pop_static_for_catalog(cosmic_raw, injection_model_metadata: di
     return log_pop_static
 
 
+def _require_npz_fields(cosmic_raw, required: list[str], context: str) -> None:
+    """Raise a clear error if an injection NPZ lacks required fields."""
+    missing = [name for name in required if name not in cosmic_raw]
+    if missing:
+        raise ValueError(
+            f"{context} requires injection catalog field(s): {', '.join(required)}; "
+            f"missing: {', '.join(missing)}"
+        )
+
+
 def load_cosmic_merger_catalog_for_selection(injections_path: str, event_model_metadata: list[dict], allow_inconsistent_selection_model: bool) -> tuple[dict, dict, bool, str]:
-    """Load COSMIC merger injection NPZ and shared proposal/static-pop accounting."""
+    """Load COSMIC merger injection NPZ and shared proposal/static-pop accounting.
+
+    The shared direct-pdet and LVK/Farr selection paths require COSMIC merger
+    hyperparameter samples and merger observables.  A direct-pdet catalog also
+    needs a valid ``pdet`` array, but that mode-specific validation is handled
+    separately by :func:`validate_direct_pdet_inputs` so LVK/Farr catalogs may
+    omit ``pdet`` or contain placeholder NaNs.
+    """
     cosmic_raw = np.load(injections_path, allow_pickle=True)
+    _require_npz_fields(
+        cosmic_raw,
+        ["theta", "params", "lower_bound", "upper_bound", "N_inj", "N_merge"],
+        "load_cosmic_merger_catalog_for_selection",
+    )
+    _require_npz_fields(
+        cosmic_raw,
+        ["m1_src", "m2_src", "z_merger"],
+        "direct_pdet and LVK/Farr selection",
+    )
     injection_model_metadata = dict(cosmic_raw["metadata"].item()) if "metadata" in cosmic_raw else {}
     injection_model_metadata.update({
         "likelihood_mode": _npz_scalar(cosmic_raw, "likelihood_mode", injection_model_metadata.get("likelihood_mode", "3D" if "z_form" in cosmic_raw else "2D")),
@@ -1624,7 +1651,7 @@ def load_cosmic_merger_catalog_for_selection(injections_path: str, event_model_m
             RuntimeWarning,
         )
         log_pop_static_arr = None
-    cosmic = dict(theta=cosmic_raw['theta'].astype(np.float64), m1_src=cosmic_raw['m1_src'].astype(np.float64) if 'm1_src' in cosmic_raw else np.array([]), m2_src=cosmic_raw['m2_src'].astype(np.float64) if 'm2_src' in cosmic_raw else np.array([]), z_merger=cosmic_raw['z_merger'].astype(np.float64) if 'z_merger' in cosmic_raw else np.array([]), pdet=cosmic_raw['pdet'].astype(np.float64) if 'pdet' in cosmic_raw else None, params=list(cosmic_raw['params']), lo=cosmic_raw['lower_bound'].astype(np.float64), hi=cosmic_raw['upper_bound'].astype(np.float64), N_inj=int(cosmic_raw['N_inj'].ravel()[0]), N_merge=int(cosmic_raw['N_merge'].ravel()[0]), kick_sigma=float(cosmic_raw['kick_proposal_sigma'].ravel()[0] if 'kick_proposal_sigma' in cosmic_raw else 50.0), log_q_proposal=log_q_arr, log_pop_static=log_pop_static_arr)
+    cosmic = dict(theta=cosmic_raw['theta'].astype(np.float64), m1_src=cosmic_raw['m1_src'].astype(np.float64), m2_src=cosmic_raw['m2_src'].astype(np.float64), z_merger=cosmic_raw['z_merger'].astype(np.float64), pdet=cosmic_raw['pdet'].astype(np.float64) if 'pdet' in cosmic_raw else None, params=list(cosmic_raw['params']), lo=cosmic_raw['lower_bound'].astype(np.float64), hi=cosmic_raw['upper_bound'].astype(np.float64), N_inj=int(cosmic_raw['N_inj'].ravel()[0]), N_merge=int(cosmic_raw['N_merge'].ravel()[0]), kick_sigma=float(cosmic_raw['kick_proposal_sigma'].ravel()[0] if 'kick_proposal_sigma' in cosmic_raw else 50.0), log_q_proposal=log_q_arr, log_pop_static=log_pop_static_arr)
     return cosmic, injection_model_metadata, selection_model_consistent, selection_model_consistency_message
 
 def lvk_found_subsample_log_scaling(N_found_total: int, N_found_used: int) -> float:

--- a/src/gwbackpop/selection/calibrate_snr_pdet.py
+++ b/src/gwbackpop/selection/calibrate_snr_pdet.py
@@ -1,4 +1,9 @@
-"""Lightweight diagnostic comparison for semi-analytic SNR-proxy pdet."""
+"""Threshold-scan diagnostic for semi-analytic SNR-proxy pdet.
+
+This utility currently computes only the SNR-proxy selection normalization.
+LVK/Farr comparison columns are emitted as NaN until Farr calibration is
+implemented here.
+"""
 from __future__ import annotations
 import argparse, csv, json
 import numpy as np
@@ -25,10 +30,11 @@ def log_alpha_snr_proxy(cosmic, lp_vec, pdet_callable):
 
 
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="Diagnostic SNR-proxy pdet alpha comparison/threshold scan.")
+    ap = argparse.ArgumentParser(description="Threshold-scan diagnostic for semi-analytic SNR-proxy pdet. LVK/Farr comparison columns are currently NaN until Farr calibration is implemented.")
     ap.add_argument("--injections_path", required=True)
     ap.add_argument("--hyperpoints_json", required=True)
     ap.add_argument("--output_csv", required=True)
+    ap.add_argument("--lvk_found_path", default=None, help="Reserved for future Farr calibration; currently accepted only to document that log_alpha_lvk_farr remains NaN.")
     ap.add_argument("--method", default="orientation_monte_carlo", choices=["hard_threshold", "orientation_monte_carlo", "logistic"])
     ap.add_argument("--rho_threshold", type=float, default=10.0)
     ap.add_argument("--sensitivity_scale", type=float, default=1.0)

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -6,6 +6,7 @@ EXPECTED = {
     "gwbackpop-run-event": "gwbackpop.cli.run_backpop:main",
     "gwbackpop-run-injections": "gwbackpop.cli.run_injections:main",
     "gwbackpop-run-hierarchical": "gwbackpop.cli.run_hierarchical:main",
+    "gwbackpop-calibrate-snr-pdet": "gwbackpop.selection.calibrate_snr_pdet:main",
     "gwbackpop-plot": "gwbackpop.cli.plot_backpop:main",
     "gwbackpop-smoke-test": "gwbackpop.cli.smoke_test:main",
 }

--- a/tests/test_selection_catalog_helper.py
+++ b/tests/test_selection_catalog_helper.py
@@ -57,3 +57,41 @@ def test_lvk_farr_reuses_shared_catalog_helper():
     lvk_part = src.split('elif selection_mode == "lvk_farr"', 1)[1]
     assert "load_cosmic_merger_catalog_for_selection" in lvk_part
     assert "log_pop_static_arr = np.zeros" not in lvk_part
+
+
+def test_catalog_helper_reports_missing_required_fields(tmp_path):
+    f = tmp_path / "missing_common.npz"
+    np.savez(f, theta=np.zeros((2, 1)))
+    with pytest.raises(ValueError, match="load_cosmic_merger_catalog_for_selection requires.*params.*lower_bound.*upper_bound.*N_inj.*N_merge"):
+        h.load_cosmic_merger_catalog_for_selection(str(f), [], True)
+
+
+def test_catalog_helper_requires_merger_observables_but_not_pdet(tmp_path):
+    f = tmp_path / "no_pdet.npz"
+    np.savez(
+        f,
+        theta=np.zeros((2, 1)),
+        params=np.array(["alpha_1"], dtype="U16"),
+        lower_bound=np.array([0.1]),
+        upper_bound=np.array([10.0]),
+        m1_src=np.array([30.0, 31.0]),
+        m2_src=np.array([20.0, 21.0]),
+        z_merger=np.array([0.1, 0.2]),
+        N_inj=np.array([5]),
+        N_merge=np.array([2]),
+    )
+    cosmic, *_ = h.load_cosmic_merger_catalog_for_selection(str(f), [], True)
+    assert cosmic["pdet"] is None
+
+    f_missing_obs = tmp_path / "missing_observables.npz"
+    np.savez(
+        f_missing_obs,
+        theta=np.zeros((2, 1)),
+        params=np.array(["alpha_1"], dtype="U16"),
+        lower_bound=np.array([0.1]),
+        upper_bound=np.array([10.0]),
+        N_inj=np.array([5]),
+        N_merge=np.array([2]),
+    )
+    with pytest.raises(ValueError, match="direct_pdet and LVK/Farr selection requires.*m1_src.*m2_src.*z_merger"):
+        h.load_cosmic_merger_catalog_for_selection(str(f_missing_obs), [], True)


### PR DESCRIPTION
### Motivation
- Ensure the new lightweight selection tests and the SNR-calibration CLI are exercised by CI and by the console-entrypoint registry test.
- Harden injection-catalog loading so missing or malformed COSMIC NPZ inputs fail early with clear errors while keeping `pdet` optional for LVK/Farr workflows.
- Make the `gwbackpop-calibrate-snr-pdet` utility explicit that it currently performs a threshold scan SNR-proxy diagnostic and does not yet compute LVK/Farr alpha.

### Description
- Update `.github/workflows/tests.yml` to add `gwbackpop-calibrate-snr-pdet --help` to the console smoke test and to run `tests/test_direct_pdet_selection.py`, `tests/test_selection_catalog_helper.py`, and `tests/test_snr_pdet_proxy.py` in the lightweight job.
- Add `"gwbackpop-calibrate-snr-pdet": "gwbackpop.selection.calibrate_snr_pdet:main"` to the expected console scripts in `tests/test_console_entrypoints.py`.
- Add `_require_npz_fields` and call-site checks in `load_cosmic_merger_catalog_for_selection` to require `theta`, `params`, `lower_bound`, `upper_bound`, `N_inj`, and `N_merge`, and to require `m1_src`, `m2_src`, and `z_merger` for direct-pdet / LVK-Farr usages, raising `ValueError` with a clear message when missing; preserve `pdet` as optional at load time (direct-pdet validation remains in `validate_direct_pdet_inputs`).
- Add regression tests `test_catalog_helper_reports_missing_required_fields` and `test_catalog_helper_requires_merger_observables_but_not_pdet` to `tests/test_selection_catalog_helper.py` to cover the new validation behavior and the optional `pdet` case.
- Rename/document `src/gwbackpop/selection/calibrate_snr_pdet.py` as a threshold-scan diagnostic by updating its module docstring and CLI help, add an optional `--lvk_found_path` CLI arg (documenting it as a placeholder), and emit `NaN` for LVK/Farr comparison columns until Farr calibration is implemented; update `README.md` accordingly.

### Testing
- Attempted `python -m pip install -e '.[test]'` which failed due to the environment PyPI proxy returning `403 Forbidden` when resolving build dependencies, so console scripts were not installed into the environment.
- Verified console modules and CLI help via `PYTHONPATH=src python -m gwbackpop.cli.smoke_test --skip-cosmic`, `PYTHONPATH=src python -m gwbackpop.cli.run_injections --help`, `PYTHONPATH=src python -m gwbackpop.cli.run_hierarchical --help`, and `PYTHONPATH=src python -m gwbackpop.selection.calibrate_snr_pdet --help`, all of which ran successfully.
- Ran the full lightweight test suite with `PYTHONPATH=src pytest tests` which completed successfully with `70 passed` (no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4283b663e0832b8d65b6ecd9a28980)