### PR TITLE
Fix debug failures injection campaign argument

### DIFF
--- a/src/gwbackpop/selection/injections.py
+++ b/src/gwbackpop/selection/injections.py
@@ -523,6 +523,7 @@ def run_campaign(
     snr_logistic_width: float = 1.0,
     snr_orientation_seed: int = 1234,
     snr_n_orientation: int = 200000,
+    debug_failures: bool = False,
 ) -> None:
     """Run the full injection campaign and save results.
 

--- a/tests/test_injection_config_metadata.py
+++ b/tests/test_injection_config_metadata.py
@@ -5,9 +5,12 @@ from gwbackpop.config import get_backpop_config
 
 
 class _FakePool:
+    initargs = ()
+
     def __init__(self, *args, **kwargs):
         init = kwargs.get("initializer")
         initargs = kwargs.get("initargs", ())
+        type(self).initargs = initargs
         if init is not None:
             init(*initargs)
 
@@ -60,3 +63,21 @@ def test_saved_injection_bounds_match_backpop_config(tmp_path, monkeypatch):
     assert bool(saved["uses_z_form"][0]) is False
     assert bool(saved["uses_sfr_prior"][0]) is False
     assert bool(saved["uses_logZ_given_z_prior"][0]) is False
+
+
+def test_run_campaign_accepts_debug_failures(tmp_path, monkeypatch):
+    _FakePool.initargs = ()
+    monkeypatch.setattr(run_injections, "Pool", _FakePool)
+    output_path = tmp_path / "injections.npz"
+
+    run_injections.run_campaign(
+        pdet_path=None,
+        output_path=str(output_path),
+        n_inj=1,
+        n_workers=1,
+        config_name="lucky_strikes",
+        debug_failures=True,
+    )
+
+    assert run_injections.DEBUG_FAILURES is True
+    assert _FakePool.initargs[-1] is True


### PR DESCRIPTION
### Motivation
- The CLI `main()` passes `debug_failures` into `run_campaign` but `run_campaign` lacked the parameter, causing a `TypeError` and preventing consistent debug-failure behavior across parent and worker processes.

### Description
- Add `debug_failures: bool = False` to the `run_campaign` function signature so the CLI can pass it without error.
- Set the global `DEBUG_FAILURES` in the parent inside `run_campaign` and forward the `debug_failures` value through `Pool(initargs=...)` so `_worker_init` receives and applies it (the worker initializer already accepts `debug_failures`).
- Add a lightweight regression test `test_run_campaign_accepts_debug_failures` in `tests/test_injection_config_metadata.py` that uses a `_FakePool` to assert that calling `run_campaign(..., debug_failures=True)` does not raise and that both the parent `DEBUG_FAILURES` and the worker `initargs` flag are set.

### Testing
- Ran the CLI help via module with `PYTHONPATH=src python -c 'from gwbackpop.cli.run_injections import main; main()' --help` which succeeded and shows the `--debug_failures` option.
- Ran the relevant tests with `PYTHONPATH=src pytest tests/test_injection_config_metadata.py tests/test_injection_proposal.py` and all tests passed (`13 passed, 1 warning`).
- Attempting the installed entrypoint `gwbackpop-run-injections --help` failed in this environment because the console script is not on `PATH` (command not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a458eb40954832b9710a0f7b5d4ca84)