### PR TITLE
Stabilize hierarchical NumPyro scales with positive floors

### DIFF
--- a/src/gwbackpop/inference/hierarchical.py
+++ b/src/gwbackpop/inference/hierarchical.py
@@ -132,19 +132,25 @@ def str2bool(value):
 
 HYPERPARAM_INFO = [
     dict(name="mu_logalpha1",  default=0.0,   prior="Normal(0.0, 1.5)"),
-    dict(name="sig_logalpha1", default=0.7,   prior="Exponential(1.0)"),
+    dict(name="sig_logalpha1", default=0.7,   prior="0.05 + Exponential(1.0)"),
     dict(name="mu_logalpha2",  default=0.0,   prior="Normal(0.0, 1.5)"),
-    dict(name="sig_logalpha2", default=0.7,   prior="Exponential(1.0)"),
-    dict(name="a_f1",          default=2.0,   prior="Gamma(2.0, 1.0)"),
-    dict(name="b_f1",          default=2.0,   prior="Gamma(2.0, 1.0)"),
-    dict(name="a_f2",          default=2.0,   prior="Gamma(2.0, 1.0)"),
-    dict(name="b_f2",          default=2.0,   prior="Gamma(2.0, 1.0)"),
-    dict(name="sigma_v1",      default=150.0, prior="HalfNormal(150.0)"),
-    dict(name="sigma_v2",      default=150.0, prior="HalfNormal(150.0)"),
+    dict(name="sig_logalpha2", default=0.7,   prior="0.05 + Exponential(1.0)"),
+    dict(name="a_f1",          default=2.0,   prior="0.05 + Gamma(2.0, 1.0)"),
+    dict(name="b_f1",          default=2.0,   prior="0.05 + Gamma(2.0, 1.0)"),
+    dict(name="a_f2",          default=2.0,   prior="0.05 + Gamma(2.0, 1.0)"),
+    dict(name="b_f2",          default=2.0,   prior="0.05 + Gamma(2.0, 1.0)"),
+    dict(name="sigma_v1",      default=150.0, prior="5.0 + HalfNormal(150.0)"),
+    dict(name="sigma_v2",      default=150.0, prior="5.0 + HalfNormal(150.0)"),
 ]
 
 POP_PARAM_NAMES = [p["name"] for p in HYPERPARAM_INFO]
 HYPERPRIOR_DESCRIPTIONS = {p["name"]: p["prior"] for p in HYPERPARAM_INFO}
+
+# Conservative positive floors used inside the NumPyro model to keep scale
+# and Beta-shape parameters away from zero-boundary funnel/pathology regions.
+DEFAULT_SIG_LOGALPHA_FLOOR = 0.05
+DEFAULT_SIGMA_V_FLOOR = 5.0
+DEFAULT_BETA_SHAPE_FLOOR = 0.05
 
 # Physical support for event/injection variables.  These are supports of the
 # population density factors and single-event/injection proposals, not support
@@ -828,7 +834,12 @@ def make_hierarchical_log_likelihood(
 # NumPyro model
 # ---------------------------------------------------------------------------
 
-def make_numpyro_model(log_likelihood_fn: callable) -> callable:
+def make_numpyro_model(
+    log_likelihood_fn: callable,
+    sig_logalpha_floor: float = DEFAULT_SIG_LOGALPHA_FLOOR,
+    sigma_v_floor: float = DEFAULT_SIGMA_V_FLOOR,
+    beta_shape_floor: float = DEFAULT_BETA_SHAPE_FLOOR,
+) -> callable:
     """Wrap the hierarchical log-likelihood as a NumPyro model.
 
     The population hyperparameters use explicit, weakly informative priors
@@ -843,41 +854,50 @@ def make_numpyro_model(log_likelihood_fn: callable) -> callable:
             "mu_logalpha1",
             dist.Normal(0.0, 1.5),
         )
-        params["sig_logalpha1"] = numpyro.sample(
-            "sig_logalpha1",
+        sig_logalpha1_raw = numpyro.sample(
+            "sig_logalpha1_raw",
             dist.Exponential(1.0),
+        )
+        params["sig_logalpha1"] = numpyro.deterministic(
+            "sig_logalpha1",
+            sig_logalpha_floor + sig_logalpha1_raw,
         )
         params["mu_logalpha2"] = numpyro.sample(
             "mu_logalpha2",
             dist.Normal(0.0, 1.5),
         )
-        params["sig_logalpha2"] = numpyro.sample(
-            "sig_logalpha2",
+        sig_logalpha2_raw = numpyro.sample(
+            "sig_logalpha2_raw",
             dist.Exponential(1.0),
         )
-        params["a_f1"] = numpyro.sample(
-            "a_f1",
-            dist.Gamma(2.0, 1.0),
+        params["sig_logalpha2"] = numpyro.deterministic(
+            "sig_logalpha2",
+            sig_logalpha_floor + sig_logalpha2_raw,
         )
-        params["b_f1"] = numpyro.sample(
-            "b_f1",
-            dist.Gamma(2.0, 1.0),
+        for name in ("a_f1", "b_f1", "a_f2", "b_f2"):
+            raw = numpyro.sample(
+                f"{name}_raw",
+                dist.Gamma(2.0, 1.0),
+            )
+            params[name] = numpyro.deterministic(
+                name,
+                beta_shape_floor + raw,
+            )
+        sigma_v1_raw = numpyro.sample(
+            "sigma_v1_raw",
+            dist.HalfNormal(150.0),
         )
-        params["a_f2"] = numpyro.sample(
-            "a_f2",
-            dist.Gamma(2.0, 1.0),
-        )
-        params["b_f2"] = numpyro.sample(
-            "b_f2",
-            dist.Gamma(2.0, 1.0),
-        )
-        params["sigma_v1"] = numpyro.sample(
+        params["sigma_v1"] = numpyro.deterministic(
             "sigma_v1",
+            sigma_v_floor + sigma_v1_raw,
+        )
+        sigma_v2_raw = numpyro.sample(
+            "sigma_v2_raw",
             dist.HalfNormal(150.0),
         )
-        params["sigma_v2"] = numpyro.sample(
+        params["sigma_v2"] = numpyro.deterministic(
             "sigma_v2",
-            dist.HalfNormal(150.0),
+            sigma_v_floor + sigma_v2_raw,
         )
 
         # Pack into a single vector for the JIT-compiled likelihood
@@ -1513,6 +1533,14 @@ def parse_args():
     sel.add_argument("--allow_inconsistent_selection_model", type=str2bool, default=False,
                      help="Explicitly allow event posterior and injection metadata to use different base measures. Intended only for legacy diagnostics.")
 
+    stab = p.add_argument_group("NumPyro stabilization")
+    stab.add_argument("--sig_logalpha_floor", type=float, default=DEFAULT_SIG_LOGALPHA_FLOOR,
+                      help="Additive floor for log-alpha scale hyperparameters.")
+    stab.add_argument("--sigma_v_floor", type=float, default=DEFAULT_SIGMA_V_FLOOR,
+                      help="Additive floor for natal-kick Maxwell scale hyperparameters [km/s].")
+    stab.add_argument("--beta_shape_floor", type=float, default=DEFAULT_BETA_SHAPE_FLOOR,
+                      help="Additive floor for beta shape hyperparameters a_f*/b_f*.")
+
     return p.parse_args()
 
 
@@ -1896,7 +1924,12 @@ def main():
         )
         print(f"  Selection diagnostics CSV: {selection_diag_path}")
 
-    model = make_numpyro_model(log_likelihood_fn)
+    model = make_numpyro_model(
+        log_likelihood_fn,
+        sig_logalpha_floor=opts.sig_logalpha_floor,
+        sigma_v_floor=opts.sigma_v_floor,
+        beta_shape_floor=opts.beta_shape_floor,
+    )
 
     # ---- NUTS sampling ----
     print(f"\n Running NUTS: {opts.num_chains} chains × "
@@ -1921,8 +1954,8 @@ def main():
     samples_dict = mcmc.get_samples(group_by_chain=True)
     # samples_dict: {param: (n_chains, n_samples)} arrays
 
-    print("\n Posterior summary:")
-    mcmc.print_summary(prob=0.9)
+    print("\n Posterior summary (population parameters; raw floor-offset sites omitted):")
+    print_summary({k: samples_dict[k] for k in POP_PARAM_NAMES if k in samples_dict}, prob=0.9)
 
     # ---- Convergence diagnostics ----
     # R-hat requires >= 2 chains. Guard gracefully for single-chain runs.
@@ -2483,6 +2516,9 @@ def main():
         num_chains       = opts.num_chains,
         r_hats           = [r_hats.get(k, np.nan) for k in POP_PARAM_NAMES],
         n_effs           = [n_effs.get(k, np.nan)  for k in POP_PARAM_NAMES],
+        sig_logalpha_floor = opts.sig_logalpha_floor,
+        sigma_v_floor = opts.sigma_v_floor,
+        beta_shape_floor = opts.beta_shape_floor,
         n_events         = n_events,
         wall_time_s      = elapsed_total,
         jax_backend      = jax.default_backend(),

--- a/tests/test_lightweight_infrastructure.py
+++ b/tests/test_lightweight_infrastructure.py
@@ -80,3 +80,34 @@ def test_toy_hierarchical_likelihood_prefers_matching_population():
     good = hb.jnp.array(good_np, dtype=hb.jnp.float64)
     bad = hb.jnp.array(bad_np, dtype=hb.jnp.float64)
     assert float(ll(good)) > float(ll(bad))
+
+
+def test_numpyro_model_applies_positive_floors_and_packs_population_order():
+    numpyro = pytest.importorskip("numpyro")
+    captured = []
+
+    def log_likelihood_fn(lp_vec):
+        captured.append(np.asarray(lp_vec, dtype=float))
+        return hb.jnp.array(0.0, dtype=hb.jnp.float64)
+
+    floors = dict(sig_logalpha_floor=0.05, sigma_v_floor=5.0, beta_shape_floor=0.05)
+    model = hb.make_numpyro_model(log_likelihood_fn, **floors)
+    seeded = numpyro.handlers.seed(model, hb.jax.random.PRNGKey(123))
+    trace = numpyro.handlers.trace(seeded).get_trace()
+
+    assert captured, "model should evaluate the likelihood with a packed lp_vec"
+    packed = captured[-1]
+    deterministic_values = np.array([np.asarray(trace[name]["value"], dtype=float) for name in hb.POP_PARAM_NAMES])
+    np.testing.assert_allclose(packed, deterministic_values)
+
+    assert float(trace["sig_logalpha1"]["value"]) >= floors["sig_logalpha_floor"]
+    assert float(trace["sig_logalpha2"]["value"]) >= floors["sig_logalpha_floor"]
+    assert float(trace["sigma_v1"]["value"]) >= floors["sigma_v_floor"]
+    assert float(trace["sigma_v2"]["value"]) >= floors["sigma_v_floor"]
+    for name in ("a_f1", "b_f1", "a_f2", "b_f2"):
+        assert float(trace[name]["value"]) >= floors["beta_shape_floor"]
+        assert f"{name}_raw" in trace
+    assert "sig_logalpha1_raw" in trace
+    assert "sig_logalpha2_raw" in trace
+    assert "sigma_v1_raw" in trace
+    assert "sigma_v2_raw" in trace


### PR DESCRIPTION
### Motivation

- Prevent NUTS divergences and zero-boundary/funnel pathologies by keeping scale and Beta-shape hyperparameters safely away from zero with conservative additive floors.
- Preserve existing downstream API/plotting names (`sig_logalpha*`, `sigma_v*`, `a_f*`, `b_f*`) while exposing the raw sampled sites separately to avoid polluting main summaries and corner plots.

### Description

- Introduce defaults `DEFAULT_SIG_LOGALPHA_FLOOR = 0.05`, `DEFAULT_SIGMA_V_FLOOR = 5.0`, and `DEFAULT_BETA_SHAPE_FLOOR = 0.05` and update `HYPERPARAM_INFO` prior descriptions to reflect the applied floors.
- Change `make_numpyro_model()` signature to accept `sig_logalpha_floor`, `sigma_v_floor`, and `beta_shape_floor`, sample raw positive variables (e.g. `sig_logalpha1_raw`, `sigma_v1_raw`, `a_f1_raw`, etc.) and create deterministic floored parameters (`sig_logalpha1`, `sigma_v1`, `a_f1`, ...).
- Ensure `lp_vec` is packed using `POP_PARAM_NAMES` order and contains the deterministic floored values (so the JIT-compiled likelihood uses the floored parameters, not raw sites).
- Add CLI options `--sig_logalpha_floor`, `--sigma_v_floor`, and `--beta_shape_floor` (with the defaults above) and propagate those values into model construction and metadata output; update posterior summary printing to show population parameters while omitting raw `_raw` sites from the main summary.
- Add a unit test `test_numpyro_model_applies_positive_floors_and_packs_population_order` that verifies deterministic floored values are >= floors, raw sites exist in the trace, and `lp_vec` uses the deterministic values in `POP_PARAM_NAMES` order.

### Testing

- Ran `PYTHONPATH=src pytest tests/test_lightweight_infrastructure.py -q`, which passed all tests (`7 passed`).
- Ran `python -m py_compile src/gwbackpop/inference/hierarchical.py`, which succeeded (syntax-checked the modified module).
- Ran `PYTHONPATH=src python -m gwbackpop.inference.hierarchical --help`, which printed the updated CLI including the new stabilization options.
- Attempted `python -m pip install -e '.[test]'` and `python -m pip install -e '.[test]' --no-build-isolation` to exercise the editable install, but these failed due to the environment's package index/build-backend availability (external to the code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45a2bf7a4c832ba9ad4cb9a4bd61cf)