### PR TITLE
Fix BackPop plot CLI directory ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The repository currently contains three main workflows. The installed console co
 Additional utilities:
 
 - `gwbackpop-run-injections` builds COSMIC merger catalogs for selection corrections. It can either store a direct `P_det(m_1, m_2, z)` value from a pickled interpolator or store `pdet=nan` for the LVK/Farr workflow.
-- `gwbackpop-plot` makes diagnostic figures from single-event output directories.
+- `gwbackpop-plot-event` makes diagnostic figures from single-event output directories.
 - `gwbackpop-calibrate-snr-pdet` runs threshold-scan diagnostics for the semi-analytic SNR-proxy detection probability. It currently writes LVK/Farr comparison columns as `NaN`; those columns should be interpreted as placeholders until Farr calibration is implemented in this utility.
 - `workflows/shell/run_hierarchical_2d.sh`, `workflows/shell/run_hierarchical_3d.sh`, and `workflows/slurm/run_catalog_gwtc3.slurm` are convenience wrappers for catalog-scale analyses.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ gwbackpop-run-event = "gwbackpop.cli.run_backpop:main"
 gwbackpop-run-injections = "gwbackpop.cli.run_injections:main"
 gwbackpop-run-hierarchical = "gwbackpop.cli.run_hierarchical:main"
 gwbackpop-calibrate-snr-pdet = "gwbackpop.selection.calibrate_snr_pdet:main"
-gwbackpop-plot = "gwbackpop.cli.plot_backpop:main"
+gwbackpop-plot-event = "gwbackpop.cli.plot_backpop:main"
+gwbackpop-plot-hierarchical = "gwbackpop.cli.plot_hierarchical:main"
 gwbackpop-smoke-test = "gwbackpop.cli.smoke_test:main"
 
 [tool.pytest.ini_options]

--- a/run_GW150914.sh
+++ b/run_GW150914.sh
@@ -89,7 +89,7 @@ if [ ! -f "${SAMPLES}" ]; then
     exit 1
 fi
 
-for cmd in gwbackpop-run-event gwbackpop-plot; do
+for cmd in gwbackpop-run-event gwbackpop-plot-event; do
     if ! command -v "${cmd}" >/dev/null 2>&1; then
         echo "ERROR: ${cmd} not found. Install the package with: python -m pip install -e '.[test]'"
         exit 1
@@ -178,7 +178,7 @@ echo ""
 echo "  Plotting 2D run (${DIR_2D})..."
 T3=$(date +%s)
 
-gwbackpop-plot \
+gwbackpop-plot-event \
     --results_dir  "${DIR_2D}" \
     --samples_path "${SAMPLES}" \
     --approximant  "${APPROXIMANT}" \
@@ -191,7 +191,7 @@ echo ""
 echo "  Plotting 3D run (${DIR_3D})..."
 T3b=$(date +%s)
 
-gwbackpop-plot \
+gwbackpop-plot-event \
     --results_dir  "${DIR_3D}" \
     --samples_path "${SAMPLES}" \
     --approximant  "${APPROXIMANT}" \
@@ -213,7 +213,7 @@ echo ""
 T4=$(date +%s)
 
 # Write comparison into the 2D directory so both share a common output
-gwbackpop-plot \
+gwbackpop-plot-event \
     --results_dir  "${DIR_2D}" \
     --compare_dir  "${DIR_3D}" \
     --samples_path "${SAMPLES}" \

--- a/src/gwbackpop/cli/plot_hierarchical.py
+++ b/src/gwbackpop/cli/plot_hierarchical.py
@@ -1,0 +1,84 @@
+"""CLI entry point for hierarchical BackPop population plots."""
+from __future__ import annotations
+
+import csv
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+
+import corner
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+PLOT_NAMES = (
+    "corner_population",
+    "population_distributions_95ci",
+    "posteriors_CE_flim",
+)
+
+
+def _load_flat_samples(samples_path: Path) -> tuple[np.ndarray, list[str]]:
+    data = np.load(samples_path)
+    if "arr_0" in data and len(data.files) == 1:
+        samples = np.asarray(data["arr_0"])
+        names = [f"param_{i}" for i in range(samples.shape[1])]
+        return samples.reshape(-1, samples.shape[-1]), names
+    names = list(data.files)
+    columns = [np.asarray(data[name]).reshape(-1) for name in names]
+    return np.column_stack(columns), names
+
+
+def _write_summary_copy(summary_path: Path, output_path: Path) -> None:
+    with summary_path.open(newline="", encoding="utf-8") as src, output_path.open("w", newline="", encoding="utf-8") as dst:
+        rows = list(csv.reader(src))
+        csv.writer(dst).writerows(rows)
+
+
+def plot_hierarchical(results_dir: str | os.PathLike[str], output_dir: str | os.PathLike[str] | None = None, fmt: str = "pdf") -> None:
+    results_path = Path(results_dir)
+    out_path = Path(output_dir) if output_dir is not None else results_path
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    samples_path = results_path / "samples.npz"
+    summary_path = results_path / "summary.csv"
+    missing = [str(path.name) for path in (samples_path, summary_path) if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "Incomplete hierarchical BackPop result directory. "
+            f"Missing required file(s): {', '.join(missing)}. Expected: samples.npz, summary.csv."
+        )
+
+    samples, names = _load_flat_samples(samples_path)
+    fig = corner.corner(samples, labels=names, quantiles=[0.05, 0.5, 0.95], show_titles=True)
+    corner_path = out_path / f"corner_population.{fmt}"
+    fig.savefig(corner_path, bbox_inches="tight", dpi=200)
+    plt.close(fig)
+    print(f"  Saved: {corner_path}")
+
+    summary_out = out_path / "population_summary.csv"
+    _write_summary_copy(summary_path, summary_out)
+    print(f"  Saved: {summary_out}")
+
+    for stem in PLOT_NAMES[1:]:
+        src = results_path / f"{stem}.pdf"
+        if src.is_file() and out_path != results_path:
+            dst = out_path / src.name
+            dst.write_bytes(src.read_bytes())
+            print(f"  Copied: {dst}")
+
+
+def parse_args():
+    parser = ArgumentParser(description="Plot hierarchical BackPop population results.")
+    parser.add_argument("--results_dir", required=True, help="Path to a hierarchical BackPop output directory containing samples.npz and summary.csv.")
+    parser.add_argument("--output_dir", default=None, help="Directory to save regenerated plots (default: same as results_dir).")
+    parser.add_argument("--fmt", default="pdf", choices=["pdf", "png", "svg"], help="Output figure format.")
+    return parser.parse_args()
+
+
+def main():
+    opts = parse_args()
+    plot_hierarchical(opts.results_dir, opts.output_dir, opts.fmt)
+
+
+__all__ = ["main", "plot_hierarchical"]

--- a/src/gwbackpop/plotting/diagnostics.py
+++ b/src/gwbackpop/plotting/diagnostics.py
@@ -44,6 +44,7 @@ import os
 import sys
 import warnings
 from argparse import ArgumentParser
+from pathlib import Path
 
 import numpy as np
 from gwbackpop.metadata import load_metadata_prefer_json
@@ -155,6 +156,71 @@ except ImportError:
 # ---------------------------------------------------------------------------
 # Data loading
 # ---------------------------------------------------------------------------
+
+SINGLE_EVENT_REQUIRED_FILES = ("points.npy", "log_w.npy", "log_z.npy", "blobs.npy", "metadata.npz")
+HIERARCHICAL_REQUIRED_FILES = ("samples.npz", "summary.csv")
+
+
+def classify_results_dir(results_dir: str | os.PathLike[str]) -> str | None:
+    """Return the recognized BackPop result directory type, if any."""
+    path = Path(results_dir)
+    has_single_event = all((path / fname).is_file() for fname in SINGLE_EVENT_REQUIRED_FILES)
+    has_hierarchical = all((path / fname).is_file() for fname in HIERARCHICAL_REQUIRED_FILES)
+    if has_single_event:
+        return "single_event"
+    if has_hierarchical:
+        return "hierarchical"
+    return None
+
+
+def missing_required_files(results_dir: str | os.PathLike[str], required_files: tuple[str, ...]) -> list[str]:
+    """List required files that are absent from ``results_dir``."""
+    path = Path(results_dir)
+    return [fname for fname in required_files if not (path / fname).is_file()]
+
+
+def describe_hierarchical_outputs(results_dir: str | os.PathLike[str]) -> list[str]:
+    """Return user-facing descriptions of hierarchical artifacts already present."""
+    path = Path(results_dir)
+    outputs = [
+        ("corner_population.pdf", "population corner plot"),
+        ("population_distributions_95ci.pdf", "population distribution credible intervals"),
+        ("posteriors_CE_flim.pdf", "CE/flim posterior diagnostics"),
+        ("summary.csv", "population summary table"),
+        ("event_reweighting_diagnostics.csv", "event reweighting diagnostics"),
+        ("selection_weight_diagnostics.csv", "selection diagnostics"),
+    ]
+    return [f"{filename} ({description})" for filename, description in outputs if (path / filename).is_file()]
+
+
+def print_hierarchical_message(results_dir: str | os.PathLike[str]) -> None:
+    """Explain that a hierarchical directory was passed to the event plotter."""
+    print("[plot_backpop] Detected a hierarchical BackPop output directory.")
+    print("[plot_backpop] This command plots single-event BackPop diagnostics and will not load log_w.npy.")
+    print("[plot_backpop] Hierarchical runs already write population outputs in this directory:")
+    outputs = describe_hierarchical_outputs(results_dir)
+    if outputs:
+        for output in outputs:
+            print(f"  - {output}")
+    else:
+        print("  - samples.npz")
+        print("  - summary.csv")
+    print("[plot_backpop] To regenerate population plots, use gwbackpop-plot-hierarchical.")
+
+
+def validate_single_event_results_dir(results_dir: str | os.PathLike[str]) -> None:
+    """Raise a clear error if a single-event result directory is incomplete."""
+    missing = missing_required_files(results_dir, SINGLE_EVENT_REQUIRED_FILES)
+    if missing:
+        missing_list = ", ".join(missing)
+        required_list = ", ".join(SINGLE_EVENT_REQUIRED_FILES)
+        raise FileNotFoundError(
+            "Incomplete single-event BackPop result directory. "
+            f"Missing required file(s): {missing_list}. "
+            f"Expected: {required_list}. "
+            "If this is a hierarchical output directory, use gwbackpop-plot-hierarchical."
+        )
+
 
 def load_results(results_dir: str, n_samples: int = 10_000) -> dict:
     """Load and process posterior samples from a BackPop results directory.
@@ -656,7 +722,7 @@ def plot_2d_vs_3d_comparison(res_2d: dict, res_3d: dict, params_compare: list[st
 def parse_args():
     p = ArgumentParser(description="Plot BackPop posterior results.")
     p.add_argument("--results_dir",  required=True,
-                   help="Path to BackPop results directory.")
+                   help="Path to a single-event BackPop result directory. For hierarchical outputs, use gwbackpop-run-hierarchical outputs directly or gwbackpop-plot-hierarchical if available.")
     p.add_argument("--compare_dir",  default=None,
                    help="Optional second results directory for 2D vs 3D comparison.")
     p.add_argument("--samples_path", default=None,
@@ -688,6 +754,12 @@ def main():
     os.makedirs(out_dir, exist_ok=True)
     fmt      = opts.fmt
     np.random.seed(42)
+
+    dir_type = classify_results_dir(opts.results_dir)
+    if dir_type == "hierarchical":
+        print_hierarchical_message(opts.results_dir)
+        return
+    validate_single_event_results_dir(opts.results_dir)
 
     print(f"[plot_backpop] Loading: {opts.results_dir}")
     res = load_results(opts.results_dir, n_samples=opts.n_samples)

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -7,7 +7,8 @@ EXPECTED = {
     "gwbackpop-run-injections": "gwbackpop.cli.run_injections:main",
     "gwbackpop-run-hierarchical": "gwbackpop.cli.run_hierarchical:main",
     "gwbackpop-calibrate-snr-pdet": "gwbackpop.selection.calibrate_snr_pdet:main",
-    "gwbackpop-plot": "gwbackpop.cli.plot_backpop:main",
+    "gwbackpop-plot-event": "gwbackpop.cli.plot_backpop:main",
+    "gwbackpop-plot-hierarchical": "gwbackpop.cli.plot_hierarchical:main",
     "gwbackpop-smoke-test": "gwbackpop.cli.smoke_test:main",
 }
 

--- a/tests/test_plot_cli_directory_types.py
+++ b/tests/test_plot_cli_directory_types.py
@@ -1,0 +1,68 @@
+import sys
+
+import numpy as np
+import pytest
+
+from gwbackpop.plotting import diagnostics
+
+
+def test_hierarchical_dir_prints_friendly_message(tmp_path, monkeypatch, capsys):
+    np.savez(tmp_path / "samples.npz", alpha=np.array([1.0, 2.0]))
+    (tmp_path / "summary.csv").write_text("parameter,mean\nalpha,1.5\n", encoding="utf-8")
+
+    called = False
+
+    def fake_load_results(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("hierarchical directories must not load event arrays")
+
+    monkeypatch.setattr(diagnostics, "load_results", fake_load_results)
+    monkeypatch.setattr(sys, "argv", ["gwbackpop-plot-event", "--results_dir", str(tmp_path)])
+
+    diagnostics.main()
+
+    output = capsys.readouterr().out
+    assert "Detected a hierarchical BackPop output directory" in output
+    assert "will not load log_w.npy" in output
+    assert "gwbackpop-plot-hierarchical" in output
+    assert not called
+
+
+def test_incomplete_dir_has_clear_missing_files_error(tmp_path, monkeypatch):
+    np.save(tmp_path / "points.npy", np.zeros((2, 2)))
+    monkeypatch.setattr(sys, "argv", ["gwbackpop-plot-event", "--results_dir", str(tmp_path)])
+
+    with pytest.raises(FileNotFoundError, match=r"Missing required file\(s\): log_w.npy, log_z.npy, blobs.npy, metadata.npz"):
+        diagnostics.main()
+
+
+def test_single_event_dir_calls_load_results(tmp_path, monkeypatch):
+    for name in diagnostics.SINGLE_EVENT_REQUIRED_FILES:
+        (tmp_path / name).write_bytes(b"placeholder")
+
+    calls = []
+
+    def fake_load_results(results_dir, n_samples):
+        calls.append((results_dir, n_samples))
+        return {
+            "event_name": "event",
+            "config_name": "config",
+            "mode": "2D",
+            "log_z": 0.0,
+            "n_eff": 1,
+            "params": ["x"],
+        }
+
+    monkeypatch.setattr(diagnostics, "load_results", fake_load_results)
+    monkeypatch.setattr(diagnostics, "plot_corner_full", lambda res: None)
+    monkeypatch.setattr(diagnostics, "plot_corner_zams", lambda res: None)
+    monkeypatch.setattr(diagnostics, "plot_corner_physics", lambda res: None)
+    monkeypatch.setattr(diagnostics, "plot_corner_kicks", lambda res: None)
+    monkeypatch.setattr(diagnostics, "plot_formation_channels", lambda res: None)
+    monkeypatch.setattr(diagnostics, "plot_delay_time", lambda res: None)
+    monkeypatch.setattr(sys, "argv", ["gwbackpop-plot-event", "--results_dir", str(tmp_path), "--n_samples", "7"])
+
+    diagnostics.main()
+
+    assert calls == [(str(tmp_path), 7)]

--- a/workflows/slurm/run_catalog_gwtc3.slurm
+++ b/workflows/slurm/run_catalog_gwtc3.slurm
@@ -146,7 +146,7 @@ EVENT="${EVENTS[${SLURM_ARRAY_TASK_ID}]}"
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENV}"
 
-for cmd in gwbackpop-run-event gwbackpop-plot; do
+for cmd in gwbackpop-run-event gwbackpop-plot-event; do
     if ! command -v "${cmd}" >/dev/null 2>&1; then
         echo "ERROR: ${cmd} not found after activating ${CONDA_ENV}."
         echo "Install with: python -m pip install -e '.[cosmic]' or activate the correct environment."
@@ -260,7 +260,7 @@ echo " [3/3]  Plotting"
 echo "─────────────────────────────────────────────────────────────"
 T3=$(date +%s)
 
-gwbackpop-plot \
+gwbackpop-plot-event \
     --results_dir  "${RESULTS_ROOT}/${EVENT}/lucky_strikes" \
     --samples_path "${SAMPLES}" \
     --n_samples    5000 \


### PR DESCRIPTION
### Motivation
- The single-event plotter attempted to load `log_w.npy` etc. from any directory, causing `FileNotFoundError` when users pointed it at hierarchical output directories that contain `samples.npz`/`summary.csv` instead of the single-event arrays.
- Make the CLI behavior friendly and explicit: detect directory type early, avoid trying to load event arrays for hierarchical outputs, and provide a dedicated hierarchical plotting entrypoint.

### Description
- Add directory classification and validation helpers (`classify_results_dir`, `validate_single_event_results_dir`, `print_hierarchical_message`, and helpers) to `src/gwbackpop/plotting/diagnostics.py` and use them to detect hierarchical vs single-event directories before calling `load_results`.
- Update the single-event CLI help to state that `--results_dir` expects a single-event results directory and reference `gwbackpop-plot-hierarchical` for hierarchical outputs.
- Add a new hierarchical plotting CLI at `src/gwbackpop/cli/plot_hierarchical.py` that loads `samples.npz` and `summary.csv`, regenerates `corner_population`, copies existing population PDFs when appropriate, and writes a population summary CSV.
- Replace the old console script name by registering `gwbackpop-plot-event = gwbackpop.cli.plot_backpop:main` and adding `gwbackpop-plot-hierarchical = gwbackpop.cli.plot_hierarchical:main` in `pyproject.toml`, and update README/workflow scripts and tests accordingly.
- Add unit tests `tests/test_plot_cli_directory_types.py` and update `tests/test_console_entrypoints.py` to cover hierarchical, incomplete, and single-event-like directories.

### Testing
- Ran targeted tests: `PYTHONPATH=src pytest -q tests/test_plot_cli_directory_types.py tests/test_console_entrypoints.py tests/test_cli_invocation_hygiene.py`, and they passed.
- Ran the package test-suite (`PYTHONPATH=src pytest -q`) which revealed one unrelated/pre-existing failure in `tests/test_injection_config_metadata.py::test_run_campaign_accepts_debug_failures` (assertion about `_FakePool.initargs`), not caused by the CLI changes.
- All new/modified tests covering the CLI behavior passed on the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45b5449df0832b9c3d6bc4993e4baf)