### PR TITLE
Avoid JAX import during adaptive injection setup

### DIFF
--- a/src/gwbackpop/inference/hierarchical.py
+++ b/src/gwbackpop/inference/hierarchical.py
@@ -109,6 +109,7 @@ from numpyro.infer import NUTS, MCMC
 from numpyro.diagnostics import print_summary, effective_sample_size, gelman_rubin
 
 from gwbackpop.metadata import base_runtime_metadata, get_package_versions, save_metadata
+from gwbackpop.population.constants import POP_PARAM_NAMES
 
 
 def str2bool(value):
@@ -143,7 +144,6 @@ HYPERPARAM_INFO = [
     dict(name="sigma_v2",      default=150.0, prior="5.0 + HalfNormal(150.0)"),
 ]
 
-POP_PARAM_NAMES = [p["name"] for p in HYPERPARAM_INFO]
 HYPERPRIOR_DESCRIPTIONS = {p["name"]: p["prior"] for p in HYPERPARAM_INFO}
 
 # Conservative positive floors used inside the NumPyro model to keep scale

--- a/src/gwbackpop/population/__init__.py
+++ b/src/gwbackpop/population/__init__.py
@@ -1,0 +1,5 @@
+"""Population-level helpers and constants."""
+
+from gwbackpop.population.constants import POP_PARAM_NAMES
+
+__all__ = ["POP_PARAM_NAMES"]

--- a/src/gwbackpop/population/constants.py
+++ b/src/gwbackpop/population/constants.py
@@ -1,0 +1,16 @@
+"""Lightweight population constants with no JAX/NumPyro imports."""
+
+from __future__ import annotations
+
+POP_PARAM_NAMES = [
+    "mu_logalpha1",
+    "sig_logalpha1",
+    "mu_logalpha2",
+    "sig_logalpha2",
+    "a_f1",
+    "b_f1",
+    "a_f2",
+    "b_f2",
+    "sigma_v1",
+    "sigma_v2",
+]

--- a/src/gwbackpop/selection/injections.py
+++ b/src/gwbackpop/selection/injections.py
@@ -72,6 +72,7 @@ from multiprocessing import Pool, cpu_count
 from scipy.stats import maxwell, beta as beta_dist, lognorm
 from scipy.special import logsumexp
 from gwbackpop.metadata import base_runtime_metadata, get_package_versions, save_metadata
+from gwbackpop.population.constants import POP_PARAM_NAMES
 
 # ---------------------------------------------------------------------------
 # Default parameter space is loaded from gwbackpop.config.get_backpop_config().
@@ -162,8 +163,6 @@ def _failure(reason: str, **extra) -> dict | None:
 
 def load_hyperposterior_samples(path: str) -> np.ndarray:
     """Load posterior samples in POP_PARAM_NAMES order from a no-selection run."""
-    from gwbackpop.inference.hierarchical import POP_PARAM_NAMES
-
     data = np.load(path, allow_pickle=True)
     if "samples" in data.files:
         arr = np.asarray(data["samples"], dtype=np.float64)
@@ -206,8 +205,6 @@ def _truncated_lognormal_logpdf(x, mu: float, sig: float, lo: float, hi: float):
 
 
 def _component_logpdf_theta(theta: np.ndarray, component: np.ndarray) -> float:
-    from gwbackpop.inference.hierarchical import POP_PARAM_NAMES
-
     hp = dict(zip(POP_PARAM_NAMES, np.asarray(component, dtype=np.float64)))
     logp = 0.0
     for name, mu, sig in (("alpha_1", hp["mu_logalpha1"], hp["sig_logalpha1"]),
@@ -260,7 +257,6 @@ def _draw_theta_adaptive(rng: np.random.Generator) -> np.ndarray:
                 i = PARAMS.index(kick_name)
                 theta[i] = _draw_truncated_maxwell(rng, KICK_PROPOSAL_SIGMA, LOWER[i], UPPER[i])
         return theta
-    from gwbackpop.inference.hierarchical import POP_PARAM_NAMES
     hp = dict(zip(POP_PARAM_NAMES, HYPERPOSTERIOR_COMPONENTS[rng.integers(len(HYPERPOSTERIOR_COMPONENTS))]))
     for name, mu, sig in (("alpha_1", hp["mu_logalpha1"], hp["sig_logalpha1"]),
                           ("alpha_2", hp["mu_logalpha2"], hp["sig_logalpha2"])):
@@ -729,6 +725,9 @@ def run_campaign(
     print(f"[injections] proposal_mode: {PROPOSAL_MODE}")
     print(f"[injections] pdet: {pdet_path_resolved}")
     print(f"[injections] output: {output_path}")
+    if "jax" in sys.modules:
+        print("[injections] WARNING: jax is already imported before multiprocessing fork; "
+              "JAX is multithreaded and may emit os.fork RuntimeWarning.")
     print()
 
     with Pool(

--- a/tests/test_injections_import_hygiene.py
+++ b/tests/test_injections_import_hygiene.py
@@ -1,0 +1,19 @@
+"""Import-hygiene checks for injection campaign generation."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_selection_injections_import_does_not_import_jax_or_numpyro():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    code = """
+import sys
+import gwbackpop.selection.injections
+assert "jax" not in sys.modules
+assert "numpyro" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
### Motivation
- Prevent JAX/NumPyro from being imported in the parent process when preparing adaptive injection campaigns to avoid the `os.fork()` JAX RuntimeWarning with multiprocessing.
- Centralize the population hyperparameter name list so lightweight modules (injection setup, tests) can import it without pulling in JAX.

### Description
- Add a lightweight module `gwbackpop.population.constants` containing `POP_PARAM_NAMES` and export it from `gwbackpop.population` so other modules can import the names without JAX/NumPyro side-effects.
- Update `gwbackpop.inference.hierarchical` to import `POP_PARAM_NAMES` from `gwbackpop.population.constants` and remove the local duplicate definition.
- Update `gwbackpop.selection.injections` to import `POP_PARAM_NAMES` from `gwbackpop.population.constants` and remove in-function imports of `gwbackpop.inference.hierarchical` from `load_hyperposterior_samples`, `_component_logpdf_theta`, and `_draw_theta_adaptive` so importing the injections module does not trigger JAX imports.
- Add a pre-fork diagnostic in `run_campaign` that prints a warning if `jax` is already present in `sys.modules` before creating the `multiprocessing.Pool`.
- Add `tests/test_injections_import_hygiene.py` which imports `gwbackpop.selection.injections` in a subprocess and asserts that `jax` and `numpyro` are not in `sys.modules`.

### Testing
- Ran `PYTHONPATH=src python -m pytest tests/test_injections_import_hygiene.py -q` and the import-hygiene test passed.
- Ran `PYTHONPATH=src python -m pytest tests/test_injections_import_hygiene.py tests/test_injection_proposal.py -q` and the combined test set passed (existing injection-proposal tests remained green).
- Ran `python -m compileall -q` on the modified modules and compilation succeeded.
- Attempted `python -m pip install -e '.[test]'` but it failed due to the environment's package index access (network/build-dependency fetch returned 403), which is an external environment issue and unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45b71ef344832b9f476c58f42ad13e)