### PR TITLE
Detect and handle COSMIC 4.1.0 evolv2 ABI (cosmic410_24) and preserve legacy_25

### DIFF
--- a/src/gwbackpop/cli/smoke_test.py
+++ b/src/gwbackpop/cli/smoke_test.py
@@ -60,8 +60,10 @@ def main() -> None:
         print(f"  cevars.alpha1 shape: {caps['cevars_alpha1_shape']}")
         print(f"  mtvars.acc_lim shape: {caps['mtvars_acc_lim_shape']}")
         print(f"  has se_flags: {caps['has_se_flags']}")
-        print(f"  evolv2 call convention: {caps['evolv2_call_convention'] or 'unknown until first call'}")
+        print(f"  evolv2 docstring first line: {caps['evolv2_docstring_first_line']}")
+        print(f"  selected evolv2 ABI convention: {caps['evolv2_call_convention'] or 'unknown until first call'}")
         print(f"  evolv2 return convention: {caps['evolv2_return_convention'] or 'unknown until first call'}")
+        print(f"  kick_info shape used: {caps['evolv2_kick_info_shape'] or 'unknown until first call'}")
 
 
 if __name__ == "__main__":

--- a/src/gwbackpop/evolution/cosmic.py
+++ b/src/gwbackpop/evolution/cosmic.py
@@ -62,6 +62,10 @@ from cosmic import _evolvebin
 _SE_FLAGS_MISSING_WARNED = False
 _EVOLV2_CALL_CONVENTION = None
 _EVOLV2_RETURN_LENGTH = None
+_EVOLV2_KICK_INFO_SHAPE = None
+
+_COSMIC410_DOC_SIGNATURE = "zpars,kick_info,bpp_index_out,bcm_index_out = evolv2"
+_COSMIC410_KICK_INFO_DOC = "kick_info : input rank-2 array('d') with bounds (2,19)"
 
 
 def _set_optional_attr(obj, attr: str, value, context: str) -> bool:
@@ -611,20 +615,126 @@ def _is_evolv2_argument_count_typeerror(exc: TypeError) -> bool:
     )
 
 
-def _call_evolv2_with_supported_abi(evolvebin, evolv2_args_24: tuple, kick_info):
-    """Call COSMIC evolv2 across known 24-arg and 25-arg f2py ABIs.
+def _evolv2_docstring(evolvebin=_evolvebin) -> str:
+    """Return the f2py docstring for the live COSMIC evolv2 function."""
+    return getattr(getattr(evolvebin, "evolv2", None), "__doc__", None) or ""
 
-    cosmic-popsynth 4.1.0 accepts 24 positional arguments and returns kick
-    information, while older builds accept a 25th in-place ``kick_info`` array.
-    Only retry TypeErrors that look like argument-count mismatches; TypeErrors
-    raised from inside COSMIC should propagate unchanged.
+
+def _evolv2_docstring_first_line(evolvebin=_evolvebin) -> str | None:
+    """Return the first non-empty line of the live evolv2 docstring."""
+    for line in _evolv2_docstring(evolvebin).splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _docstring_declares_cosmic410_24(evolvebin=_evolvebin) -> bool:
+    """Return True when f2py metadata matches the COSMIC 4.1.0 evolv2 ABI."""
+    doc = _evolv2_docstring(evolvebin)
+    normalized = " ".join(doc.split())
+    return (
+        _COSMIC410_DOC_SIGNATURE in normalized
+        and _COSMIC410_KICK_INFO_DOC in normalized
+    )
+
+
+def _select_evolv2_abi(evolvebin=_evolvebin) -> str:
+    """Select and cache the known evolv2 ABI convention for this process."""
+    global _EVOLV2_CALL_CONVENTION
+    if _EVOLV2_CALL_CONVENTION is not None:
+        return _EVOLV2_CALL_CONVENTION
+    if _docstring_declares_cosmic410_24(evolvebin):
+        _EVOLV2_CALL_CONVENTION = "cosmic410_24"
+    else:
+        _EVOLV2_CALL_CONVENTION = "legacy_25"
+    return _EVOLV2_CALL_CONVENTION
+
+
+def _kick_info_shape_for_abi(convention: str) -> tuple[int, int]:
+    if convention == "cosmic410_24":
+        return (2, 19)
+    if convention == "legacy_25":
+        return (2, 18)
+    raise ValueError(f"Unknown COSMIC evolv2 ABI convention: {convention}")
+
+
+def _call_evolv2_with_supported_abi(
+    evolvebin,
+    evolv2_args_cosmic410_24: tuple,
+    bkick,
+    kick_info,
+    convention: str | None = None,
+):
+    """Call COSMIC evolv2 using the selected, convention-aware ABI.
+
+    ``cosmic410_24`` is the COSMIC 4.1.0 f2py ABI:
+    (..., bhspin, tphys, zpars, kick_info_2x19).  It has no ``bkick``
+    argument and returns ``(zpars, kick_info, bpp_index, bcm_index)``.
+
+    ``legacy_25`` preserves the older ABI:
+    (..., bhspin, tphys, zpars, bkick, kick_info_2x18_or_existing).
     """
-    try:
-        return evolvebin.evolv2(*evolv2_args_24), "24-arg"
-    except TypeError as exc:
-        if not _is_evolv2_argument_count_typeerror(exc):
-            raise
-        return evolvebin.evolv2(*evolv2_args_24, kick_info), "25-arg"
+    if convention is None:
+        convention = _select_evolv2_abi(evolvebin)
+
+    if convention == "cosmic410_24":
+        return evolvebin.evolv2(*evolv2_args_cosmic410_24), convention
+
+    if convention != "legacy_25":
+        raise ValueError(f"Unknown COSMIC evolv2 ABI convention: {convention}")
+
+    legacy_args = (*evolv2_args_cosmic410_24[:-1], bkick, kick_info)
+    return evolvebin.evolv2(*legacy_args), convention
+
+
+def _parse_evolv2_return(evolv2_out, convention: str, kick_info):
+    """Parse COSMIC evolv2 output into (bpp_index, bcm_index, kick_info)."""
+    evolv2_return_length = len(evolv2_out)
+
+    def _scalar_int(x, name):
+        arr = np.asarray(x)
+        if arr.shape == ():
+            return int(arr)
+        if arr.size == 1:
+            return int(arr.ravel()[0])
+        raise TypeError(
+            f"COSMIC returned non-scalar {name}: "
+            f"shape={arr.shape}, dtype={arr.dtype}"
+        )
+
+    if convention == "cosmic410_24":
+        if evolv2_return_length != 4:
+            raise RuntimeError(
+                "COSMIC cosmic410_24 evolv2 returned "
+                f"{evolv2_return_length} values, expected 4."
+            )
+        _zpars_out, kick_info_arrays, bpp_index, bcm_index = evolv2_out
+    elif convention == "legacy_25":
+        if evolv2_return_length == 4:
+            _, bpp_index, bcm_index, kick_info_arrays = evolv2_out
+        elif evolv2_return_length == 3:
+            a, b, c = evolv2_out
+            try:
+                bpp_index = _scalar_int(a, "bpp_index")
+                bcm_index = _scalar_int(b, "bcm_index")
+                kick_info_arrays = c
+            except TypeError:
+                _, bpp_index, bcm_index = evolv2_out
+                kick_info_arrays = kick_info
+        else:
+            raise RuntimeError(
+                f"Unexpected COSMIC evolv2 return length: {evolv2_return_length}"
+            )
+    else:
+        raise ValueError(f"Unknown COSMIC evolv2 ABI convention: {convention}")
+
+    return (
+        _scalar_int(bpp_index, "bpp_index"),
+        _scalar_int(bcm_index, "bcm_index"),
+        np.asarray(kick_info_arrays),
+        evolv2_return_length,
+    )
 
 
 def _shape_or_none(value):
@@ -649,15 +759,20 @@ def get_cosmic_capabilities(
         cosmic_version = metadata.version("cosmic-popsynth")
     except metadata.PackageNotFoundError:
         cosmic_version = None
+    kick_info_shape = _EVOLV2_KICK_INFO_SHAPE
+    if kick_info_shape is None and evolv2_call_convention is not None:
+        kick_info_shape = _kick_info_shape_for_abi(evolv2_call_convention)
     return {
         "cosmic_popsynth_version": cosmic_version,
         "cevars_alpha1_shape": _shape_or_none(getattr(_evolvebin.cevars, "alpha1", None)),
         "mtvars_acc_lim_shape": _shape_or_none(getattr(_evolvebin.mtvars, "acc_lim", None)),
         "has_se_flags": hasattr(_evolvebin, "se_flags"),
+        "evolv2_docstring_first_line": _evolv2_docstring_first_line(_evolvebin),
         "evolv2_call_convention": evolv2_call_convention,
         "evolv2_return_convention": (
             None if evolv2_return_length is None else f"len={evolv2_return_length}"
         ),
+        "evolv2_kick_info_shape": kick_info_shape,
     }
 
 
@@ -779,59 +894,29 @@ def evolv2(
     bhspin   = np.zeros(2)
     zpars    = np.zeros(20)
     bkick    = np.zeros(20)
-    kick_info = np.zeros((2, 18))
+    evolv2_call_convention = _select_evolv2_abi(_evolvebin)
+    kick_info = np.zeros(_kick_info_shape_for_abi(evolv2_call_convention), dtype=float)
 
     # ---- Call COSMIC Fortran kernel ----
-    # COSMIC ABI differs across cosmic-popsynth builds.
-    # Known variants:
-    #   4-return: (_, bpp_index, bcm_index, kick_info_arrays)
-    #   3-return: (bpp_index, bcm_index, kick_info_arrays)
-    #   3-return older fallback: (_, bpp_index, bcm_index), with kick_info filled in-place.
-    evolv2_args_24 = (
+    # COSMIC ABI differs across cosmic-popsynth builds.  COSMIC 4.1.0 uses
+    # (..., bhspin, tphys, zpars, kick_info_2x19) with no bkick argument;
+    # legacy builds use (..., bhspin, tphys, zpars, bkick, kick_info_2x18).
+    evolv2_args_cosmic410_24 = (
         kstar, mass, tb, e, metallicity, tphysf,
         dtp, mass0, rad, lumin, massc, radc,
         menv, renv, ospin, B_0, bacc, tacc, epoch, tms,
-        bhspin, tphys, zpars, bkick,
+        bhspin, tphys, zpars, kick_info,
     )
     evolv2_out, evolv2_call_convention = _call_evolv2_with_supported_abi(
-        _evolvebin, evolv2_args_24, kick_info
+        _evolvebin, evolv2_args_cosmic410_24, bkick, kick_info, evolv2_call_convention
     )
-    evolv2_return_length = len(evolv2_out)
-    global _EVOLV2_CALL_CONVENTION, _EVOLV2_RETURN_LENGTH
+    bpp_index, bcm_index, kick_info_arrays, evolv2_return_length = _parse_evolv2_return(
+        evolv2_out, evolv2_call_convention, kick_info
+    )
+    global _EVOLV2_CALL_CONVENTION, _EVOLV2_RETURN_LENGTH, _EVOLV2_KICK_INFO_SHAPE
     _EVOLV2_CALL_CONVENTION = evolv2_call_convention
     _EVOLV2_RETURN_LENGTH = evolv2_return_length
-
-    def _scalar_int(x, name):
-        arr = np.asarray(x)
-        if arr.shape == ():
-            return int(arr)
-        if arr.size == 1:
-            return int(arr.ravel()[0])
-        raise TypeError(
-            f"COSMIC returned non-scalar {name}: "
-            f"shape={arr.shape}, dtype={arr.dtype}"
-        )
-
-    if evolv2_return_length == 4:
-        _, bpp_index, bcm_index, kick_info_arrays = evolv2_out
-    elif evolv2_return_length == 3:
-        a, b, c = evolv2_out
-        # Most COSMIC 3.x builds return (bpp_index, bcm_index, kick_info_arrays).
-        # If that is not true, fall back to (_, bpp_index, bcm_index).
-        try:
-            bpp_index = _scalar_int(a, "bpp_index")
-            bcm_index = _scalar_int(b, "bcm_index")
-            kick_info_arrays = c
-        except TypeError:
-            _, bpp_index, bcm_index = evolv2_out
-            kick_info_arrays = kick_info
-    else:
-        raise RuntimeError(
-            f"Unexpected COSMIC evolv2 return length: {evolv2_return_length}"
-        )
-
-    bpp_index = _scalar_int(bpp_index, "bpp_index")
-    bcm_index = _scalar_int(bcm_index, "bcm_index")
+    _EVOLV2_KICK_INFO_SHAPE = tuple(kick_info.shape)
 
     # ---- Extract and clear output arrays (avoids Fortran global state leakage) ----
     bpp_raw = _evolvebin.binary.bpp[:25, :n_col_bpp].copy()

--- a/tests/test_cosmic_evolv2_abi.py
+++ b/tests/test_cosmic_evolv2_abi.py
@@ -11,6 +11,13 @@ import numpy as np
 import pytest
 
 
+COSMIC410_DOC = """
+zpars,kick_info,bpp_index_out,bcm_index_out = evolv2(kstar,mass,tb,ecc,z,tphysf,dtp,mass0,rad,lumin,massc,radc,menv,renv,ospin,b_0,bacc,tacc,epoch,tms,bhspin,tphys,zpars,kick_info)
+
+kick_info : input rank-2 array('d') with bounds (2,19)
+"""
+
+
 def _install_fake_cosmic(monkeypatch, evolvebin):
     fake_cosmic = types.ModuleType("cosmic")
     fake_cosmic._evolvebin = evolvebin
@@ -19,65 +26,100 @@ def _install_fake_cosmic(monkeypatch, evolvebin):
     return importlib.import_module("gwbackpop.evolution.cosmic")
 
 
-class FakeEvolvebin24:
+class FakeEvolv2Callable:
+    def __init__(self, owner, doc):
+        self.owner = owner
+        self.__doc__ = doc
+
+    def __call__(self, *args):
+        return self.owner._evolv2(*args)
+
+
+class FakeEvolvebin410:
     def __init__(self):
         self.arg_counts = []
+        self.received_bkick = False
+        self.evolv2 = FakeEvolv2Callable(self, COSMIC410_DOC)
 
-    def evolv2(self, *args):
+    def _evolv2(self, *args):
         self.arg_counts.append(len(args))
         if len(args) != 24:
-            raise TypeError(f"evolv2() takes at most 24 arguments ({len(args)} given)")
-        return 1, 2, np.zeros((2, 18))
+            raise TypeError(f"evolv2() takes exactly 24 positional arguments ({len(args)} given)")
+        kick_info = args[-1]
+        if np.shape(kick_info) != (2, 19):
+            raise ValueError(f"0-th dimension must be fixed to 2 but got {np.shape(kick_info)}")
+        # bkick was the old final 24th argument and has shape (20,); ensure it was not passed.
+        self.received_bkick = np.shape(args[-1]) == (20,)
+        return args[-2], kick_info + 1.0, np.array(7), np.array([9])
 
 
 class FakeEvolvebin25:
     def __init__(self):
         self.arg_counts = []
+        self.evolv2 = FakeEvolv2Callable(self, "legacy evolv2 doc")
 
-    def evolv2(self, *args):
+    def _evolv2(self, *args):
         self.arg_counts.append(len(args))
         if len(args) != 25:
             raise TypeError(f"evolv2() takes exactly 25 positional arguments ({len(args)} given)")
-        return None, 1, 2
+        bkick = args[-2]
+        kick_info = args[-1]
+        assert np.shape(bkick) == (20,)
+        assert np.shape(kick_info) == (2, 18)
+        return None, 3, np.array(4), kick_info + 2.0
 
 
-class FakeEvolvebinBadTypeError:
-    def evolv2(self, *args):
-        raise TypeError("ufunc 'isfinite' not supported for the input types")
-
-
-def test_evolv2_24_arg_fake_passes(monkeypatch):
-    fake = FakeEvolvebin24()
+def test_cosmic410_24_fake_uses_no_bkick_and_shape_2x19(monkeypatch):
+    fake = FakeEvolvebin410()
     cosmic_mod = _install_fake_cosmic(monkeypatch, fake)
+    kick_info = np.zeros((2, 19))
 
     out, convention = cosmic_mod._call_evolv2_with_supported_abi(
-        fake, tuple(range(24)), np.zeros((2, 18))
+        fake, (*tuple(range(23)), kick_info), np.zeros(20), kick_info
     )
 
-    assert convention == "24-arg"
-    assert len(out) == 3
+    assert convention == "cosmic410_24"
     assert fake.arg_counts == [24]
+    assert fake.received_bkick is False
+    bpp_index, bcm_index, kick_arrays, ret_len = cosmic_mod._parse_evolv2_return(
+        out, convention, kick_info
+    )
+    assert (bpp_index, bcm_index, ret_len) == (7, 9, 4)
+    assert kick_arrays.shape == (2, 19)
 
 
-def test_evolv2_25_arg_fake_passes(monkeypatch):
+def test_legacy_25_fake_requires_bkick_and_kick_info(monkeypatch):
     fake = FakeEvolvebin25()
     cosmic_mod = _install_fake_cosmic(monkeypatch, fake)
+    kick_info = np.zeros((2, 18))
 
     out, convention = cosmic_mod._call_evolv2_with_supported_abi(
-        fake, tuple(range(24)), np.zeros((2, 18))
+        fake, (*tuple(range(23)), kick_info), np.zeros(20), kick_info
     )
 
-    assert convention == "25-arg"
-    assert len(out) == 3
-    assert fake.arg_counts == [24, 25]
+    assert convention == "legacy_25"
+    assert fake.arg_counts == [25]
+    bpp_index, bcm_index, kick_arrays, ret_len = cosmic_mod._parse_evolv2_return(
+        out, convention, kick_info
+    )
+    assert (bpp_index, bcm_index, ret_len) == (3, 4, 4)
+    assert kick_arrays.shape == (2, 18)
 
 
 def test_non_argument_typeerror_is_not_swallowed(monkeypatch):
-    fake = FakeEvolvebinBadTypeError()
+    class FakeBad(FakeEvolvebin25):
+        def _evolv2(self, *args):
+            raise TypeError("ufunc 'isfinite' not supported for the input types")
+
+    fake = FakeBad()
     cosmic_mod = _install_fake_cosmic(monkeypatch, fake)
 
+    # The convention-aware caller no longer retries legacy calls after docstring
+    # selection, so internal TypeErrors should propagate unchanged.
     with pytest.raises(TypeError, match="ufunc 'isfinite'"):
-        cosmic_mod._call_evolv2_with_supported_abi(fake, tuple(range(24)), np.zeros((2, 18)))
+        cosmic_mod._call_evolv2_with_supported_abi(
+            fake, (*tuple(range(23)), np.zeros((2, 18))), np.zeros(20), np.zeros((2, 18))
+        )
 
 
 def test_vector_alpha_flim_capability_passes_independent_check(monkeypatch):
@@ -85,6 +127,7 @@ def test_vector_alpha_flim_capability_passes_independent_check(monkeypatch):
         cevars=types.SimpleNamespace(alpha1=np.ones(2)),
         mtvars=types.SimpleNamespace(acc_lim=np.ones(2)),
         se_flags=types.SimpleNamespace(),
+        evolv2=FakeEvolv2Callable(types.SimpleNamespace(_evolv2=lambda *args: None), COSMIC410_DOC),
     )
     cosmic_mod = _install_fake_cosmic(monkeypatch, fake)
 
@@ -93,4 +136,5 @@ def test_vector_alpha_flim_capability_passes_independent_check(monkeypatch):
     assert caps["cevars_alpha1_shape"] == (2,)
     assert caps["mtvars_acc_lim_shape"] == (2,)
     assert caps["has_se_flags"] is True
+    assert caps["evolv2_docstring_first_line"].startswith("zpars,kick_info")
     cosmic_mod.require_independent_alpha_flim_capability()


### PR DESCRIPTION
### Motivation
- COSMIC 4.1.0 changed the f2py `evolv2` ABI: it passes `kick_info` as the 24th argument (shape `(2,19)`) and returns `(zpars, kick_info, bpp_index, bcm_index)`, so the previous assumption (old-minus-one ordering) caused shape/TypeErrors. 

### Description
- Add docstring-based detection for the COSMIC 4.1.0 ABI and cache the selected convention as either `cosmic410_24` or `legacy_25` in `src/gwbackpop/evolution/cosmic.py`. 
- Implement convention-aware call sites and allocation: `cosmic410_24` uses no `bkick` and allocates `kick_info = np.zeros((2,19))`, while `legacy_25` preserves the old `bkick` + `kick_info = np.zeros((2,18))`. 
- Add a return parser that understands `cosmic410_24` returns `(zpars, kick_info, bpp_index, bcm_index)` and keeps existing legacy parsing for 3- or 4-value returns, normalizing scalar `bpp_index`/`bcm_index` as needed. 
- Cache the chosen ABI and record the used `kick_info` shape for later diagnostics, and extend the smoke-test doctor output in `src/gwbackpop/cli/smoke_test.py` to show the `evolv2` docstring first line, selected ABI convention, and `kick_info` shape. 
- Update and extend tests in `tests/test_cosmic_evolv2_abi.py` to fake a COSMIC 4.1.0 `evolv2` (no `bkick`, `(2,19)` `kick_info`) and a legacy 25-arg `evolv2`, and add parsing/shape assertions. 

### Testing
- Ran the targeted ABI tests: `pytest -q tests/test_cosmic_evolv2_abi.py` (4 passed). 
- Ran the smoke doctor with COSMIC skipped: `PYTHONPATH=src python -m gwbackpop.cli.smoke_test --skip-cosmic` (passed). 
- Attempted the acceptance smoke invoking `evolv2` against a live COSMIC install but could not run it here because `cosmic` / `cosmic-popsynth` is not installed in this environment. 
- Ran the full test suite: `pytest -q` produced one unrelated failure in `tests/test_injection_config_metadata.py::test_run_campaign_accepts_debug_failures` while all ABI-related tests still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46391ef104832bb9195d78fb5807b1)