### PR TITLE
Fix COSMIC kick_info postprocessing

### DIFF
--- a/src/gwbackpop/cli/smoke_test.py
+++ b/src/gwbackpop/cli/smoke_test.py
@@ -64,6 +64,7 @@ def main() -> None:
         print(f"  selected evolv2 ABI convention: {caps['evolv2_call_convention'] or 'unknown until first call'}")
         print(f"  evolv2 return convention: {caps['evolv2_return_convention'] or 'unknown until first call'}")
         print(f"  kick_info shape used: {caps['evolv2_kick_info_shape'] or 'unknown until first call'}")
+        print(f"  kick_info columns used: {caps['evolv2_kick_info_columns'] or 'unknown until first call'}")
 
 
 if __name__ == "__main__":

--- a/src/gwbackpop/evolution/cosmic.py
+++ b/src/gwbackpop/evolution/cosmic.py
@@ -63,6 +63,7 @@ _SE_FLAGS_MISSING_WARNED = False
 _EVOLV2_CALL_CONVENTION = None
 _EVOLV2_RETURN_LENGTH = None
 _EVOLV2_KICK_INFO_SHAPE = None
+_EVOLV2_KICK_INFO_COLUMNS = None
 
 _COSMIC410_DOC_SIGNATURE = "zpars,kick_info,bpp_index_out,bcm_index_out = evolv2"
 _COSMIC410_KICK_INFO_DOC = "kick_info : input rank-2 array('d') with bounds (2,19)"
@@ -214,6 +215,46 @@ KICK_COLUMNS = [
 # Fixed array shapes for Nautilus blob storage
 BPP_SHAPE = (25, len(COLS_KEEP))
 KICK_SHAPE = (2, len(KICK_COLUMNS))
+
+
+def _kick_columns_for_array(kick_info_arrays):
+    """Return kick_info DataFrame columns matching the live COSMIC array width."""
+    n_col = np.asarray(kick_info_arrays).shape[1]
+    if n_col == len(KICK_COLUMNS):
+        return KICK_COLUMNS
+    if n_col == len(KICK_COLUMNS) + 1:
+        return list(KICK_COLUMNS) + ["kick_info_extra_18"]
+    if n_col < len(KICK_COLUMNS):
+        return list(KICK_COLUMNS[:n_col])
+    return list(KICK_COLUMNS) + [
+        f"kick_info_extra_{i}" for i in range(len(KICK_COLUMNS), n_col)
+    ]
+
+
+def _kick_index_for_array(kick_info_arrays):
+    """Return an event/order index from the final column, or None if invalid."""
+    try:
+        last_col = np.asarray(kick_info_arrays)[:, -1]
+        if not np.all(np.isfinite(last_col)):
+            return None
+        if not np.all(np.isclose(last_col, np.rint(last_col))):
+            return None
+        idx = last_col.astype(int)
+        if len(np.unique(idx)) != len(idx):
+            return None
+        return idx
+    except Exception:
+        return None
+
+
+def _kick_dataframe_from_array(kick_info_arrays):
+    """Build a robust kick_info DataFrame across COSMIC ABI widths."""
+    kick_cols = _kick_columns_for_array(kick_info_arrays)
+    kick_df = pd.DataFrame(kick_info_arrays, columns=kick_cols)
+    idx = _kick_index_for_array(kick_info_arrays)
+    if idx is not None:
+        kick_df.index = idx
+    return kick_df
 
 
 # ---------------------------------------------------------------------------
@@ -760,6 +801,7 @@ def get_cosmic_capabilities(
     except metadata.PackageNotFoundError:
         cosmic_version = None
     kick_info_shape = _EVOLV2_KICK_INFO_SHAPE
+    kick_info_columns = _EVOLV2_KICK_INFO_COLUMNS
     if kick_info_shape is None and evolv2_call_convention is not None:
         kick_info_shape = _kick_info_shape_for_abi(evolv2_call_convention)
     return {
@@ -773,6 +815,7 @@ def get_cosmic_capabilities(
             None if evolv2_return_length is None else f"len={evolv2_return_length}"
         ),
         "evolv2_kick_info_shape": kick_info_shape,
+        "evolv2_kick_info_columns": kick_info_columns,
     }
 
 
@@ -913,10 +956,12 @@ def evolv2(
     bpp_index, bcm_index, kick_info_arrays, evolv2_return_length = _parse_evolv2_return(
         evolv2_out, evolv2_call_convention, kick_info
     )
-    global _EVOLV2_CALL_CONVENTION, _EVOLV2_RETURN_LENGTH, _EVOLV2_KICK_INFO_SHAPE
+    global _EVOLV2_CALL_CONVENTION, _EVOLV2_RETURN_LENGTH
+    global _EVOLV2_KICK_INFO_SHAPE, _EVOLV2_KICK_INFO_COLUMNS
     _EVOLV2_CALL_CONVENTION = evolv2_call_convention
     _EVOLV2_RETURN_LENGTH = evolv2_return_length
-    _EVOLV2_KICK_INFO_SHAPE = tuple(kick_info.shape)
+    _EVOLV2_KICK_INFO_SHAPE = tuple(np.asarray(kick_info_arrays).shape)
+    _EVOLV2_KICK_INFO_COLUMNS = _kick_columns_for_array(kick_info_arrays)
 
     # ---- Extract and clear output arrays (avoids Fortran global state leakage) ----
     bpp_raw = _evolvebin.binary.bpp[:25, :n_col_bpp].copy()
@@ -927,11 +972,7 @@ def evolv2(
 
     # ---- Build DataFrames ----
     bpp = pd.DataFrame(bpp_raw, columns=BPP_COLUMNS)[COLS_KEEP]
-    kick_df = pd.DataFrame(
-        kick_info_arrays,
-        columns=KICK_COLUMNS,
-        index=kick_info_arrays[:, -1].astype(int),
-    )
+    kick_df = _kick_dataframe_from_array(kick_info_arrays)
 
     # ---- Find merger row: BBH (kstar=14/14) that inspirals (evol_type=3) ----
     merger_mask = (
@@ -945,9 +986,7 @@ def evolv2(
 
     final_state = merger_rows[params_out].iloc[0]
     bpp_array   = bpp.to_numpy()
-    kick_array  = kick_df.to_numpy()
-
-    return final_state, bpp_array, kick_array
+    return final_state, bpp_array, kick_df
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cosmic_evolv2_abi.py
+++ b/tests/test_cosmic_evolv2_abi.py
@@ -138,3 +138,48 @@ def test_vector_alpha_flim_capability_passes_independent_check(monkeypatch):
     assert caps["has_se_flags"] is True
     assert caps["evolv2_docstring_first_line"].startswith("zpars,kick_info")
     cosmic_mod.require_independent_alpha_flim_capability()
+
+
+def test_kick_columns_legacy_width_uses_exact_names(monkeypatch):
+    cosmic_mod = _install_fake_cosmic(monkeypatch, FakeEvolvebin25())
+    arr = np.zeros((2, 18))
+
+    assert cosmic_mod._kick_columns_for_array(arr) == cosmic_mod.KICK_COLUMNS
+
+
+def test_kick_dataframe_cosmic410_width_appends_one_extra_column(monkeypatch):
+    cosmic_mod = _install_fake_cosmic(monkeypatch, FakeEvolvebin410())
+    arr = np.zeros((2, 19))
+    arr[:, -1] = [10, 11]
+
+    kick_df = cosmic_mod._kick_dataframe_from_array(arr)
+
+    assert list(kick_df.columns) == cosmic_mod.KICK_COLUMNS + ["kick_info_extra_18"]
+    assert list(kick_df.index) == [10, 11]
+    assert kick_df.shape == (2, 19)
+
+
+def test_kick_dataframe_wider_width_appends_numbered_extra_columns(monkeypatch):
+    cosmic_mod = _install_fake_cosmic(monkeypatch, FakeEvolvebin410())
+    arr = np.zeros((2, 20))
+    arr[:, -1] = [20, 21]
+
+    kick_df = cosmic_mod._kick_dataframe_from_array(arr)
+
+    assert list(kick_df.columns) == cosmic_mod.KICK_COLUMNS + [
+        "kick_info_extra_18",
+        "kick_info_extra_19",
+    ]
+    assert list(kick_df.index) == [20, 21]
+    assert kick_df.shape == (2, 20)
+
+
+def test_kick_dataframe_weird_last_column_uses_default_range_index(monkeypatch):
+    cosmic_mod = _install_fake_cosmic(monkeypatch, FakeEvolvebin410())
+    arr = np.zeros((2, 19))
+    arr[:, -1] = [1.25, np.nan]
+
+    kick_df = cosmic_mod._kick_dataframe_from_array(arr)
+
+    assert list(kick_df.index) == [0, 1]
+    assert list(kick_df.columns)[-1] == "kick_info_extra_18"


### PR DESCRIPTION
### Motivation
- COSMIC 4.1 returns `kick_info` arrays with 19 columns while the code assumed 18, causing a `ValueError` when constructing the `kick_info` DataFrame.  
- The previous logic also unconditionally used the final column as an integer index, which is brittle when the column semantics/width change.  
- The doctor/smoke output lacked visibility into which `kick_info` columns were actually used at runtime.

### Description
- Add `_kick_columns_for_array`, `_kick_index_for_array`, and `_kick_dataframe_from_array` helpers to select appropriate column names for 18/19/+ widths and to safely build a `kick_info` `DataFrame` with a guarded index fallback.  
- Update `evolv2` to use the new `_kick_dataframe_from_array`, record the detected `kick_info` shape and columns in module-level diagnostics (`_EVOLV2_KICK_INFO_SHAPE` / `_EVOLV2_KICK_INFO_COLUMNS`), and return the `kick_info` `DataFrame`.  
- Extend `get_cosmic_capabilities` and the smoke test output to include `evolv2_kick_info_columns` so the selected columns are visible in doctor/smoke output.

### Testing
- Ran `pytest -q tests/test_cosmic_evolv2_abi.py` and all tests passed (8 passed).  
- Compiled the modified modules with `python -m py_compile src/gwbackpop/evolution/cosmic.py src/gwbackpop/cli/smoke_test.py` with no syntax errors.  
- Attempted the acceptance smoke (`PYTHONPATH=src python - <<'PY' ...`) but it was blocked in this environment because the `cosmic` package is not installed, so the live COSMIC acceptance run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a463c30ed04832ba7ed842d3dec3b57)